### PR TITLE
Add dynamic home allowlist include

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -54,6 +54,13 @@
         not remote_ip 10.2.11.0/24
 }
 
+# Managed by external automation with the current public home IPv4/IPv6 prefix.
+(dynamic_home_allowlist) {
+        @from_dynamic_home {
+                import /etc/caddy/dynamic/home-allowlist.caddy
+        }
+}
+
 # use this import if you want to be able to fallback to basic auth
 (mTLS_optional) {
         tls {
@@ -102,6 +109,8 @@ dms.{$CADDY_SUBDOMAIN} {
 }
 
 # Uncomment this in addition with the import admin_redir statement allow access to the admin interface only from local networks
+# For home access behind a Fritzbox, prefer `import dynamic_home_allowlist` and `@from_dynamic_home`
+# over `remote_ip private_ranges`, because Caddy usually only sees the public WAN IPv4/IPv6.
 (admin_redir) {
         @admin {
                 path /admin*
@@ -206,3 +215,4 @@ n8n.{$CADDY_SUBDOMAIN3} {
                         }
                 }
         }
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # caddy-rproxy
-Caddy Reversproxy docker-compose 
+
+Caddy reverse proxy docker-compose setup.
+
+## Dynamic Home Allowlist
+
+Use this when Caddy sits behind a Fritzbox and should trust the currently assigned public home IPv4 plus delegated IPv6 prefix instead of `private_ranges`.
+
+- `dynamic/home-allowlist.caddy` is bind-mounted to `/etc/caddy/dynamic/home-allowlist.caddy`.
+- The file is intended to be updated by automation such as `Fritzbox -> n8n`.
+- Keep the file content as a single valid `remote_ip ...` directive, for example:
+
+```caddyfile
+remote_ip 198.51.100.24/32 2001:db8:1234:5600::/56
+```
+
+- After updating the file, reload Caddy with:
+
+```sh
+docker compose exec caddy caddy reload --config /etc/caddy/Caddyfile
+```
+
+Because the allowlist lives in the bind-mounted `dynamic/` directory, the latest values survive a Caddy container restart as long as the file is kept up to date.
+
+In the `Caddyfile`, import the matcher snippet with `import dynamic_home_allowlist` and then use `@from_dynamic_home` where a site needs the dynamic home-IP allowlist.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: caddy:2.11.1@sha256:9068f76202c0a03545036d32bf2d424d3b46c1174f254070f605002a2dbc9657
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
+      - ./dynamic:/etc/caddy/dynamic
       - ./site:/srv
       - /opt/docker/caddy/data:/data
       - /opt/docker/caddy/caddy_config:/config

--- a/dynamic/home-allowlist.caddy
+++ b/dynamic/home-allowlist.caddy
@@ -1,0 +1,4 @@
+# Managed by automation.
+# Keep this file syntactically valid at all times so Caddy can reload safely.
+# Replace these documentation-only networks with the current public IPv4 and delegated IPv6 prefix.
+remote_ip 192.0.2.1/32 2001:db8::/128


### PR DESCRIPTION
## Summary
- add a bind-mounted dynamic allowlist file for the current public home IPv4 and IPv6 prefix
- add a reusable Caddy matcher snippet for home-IP based exceptions behind a Fritzbox
- document how external automation can update the file and reload Caddy

## Details
This PR adds a small persistent `dynamic/` include that can be maintained by external automation such as `Fritzbox -> n8n`.

The new snippet in `Caddyfile` defines `@from_dynamic_home` by importing `/etc/caddy/dynamic/home-allowlist.caddy`. The file is mounted from the repository so the latest known IPv4 and IPv6 prefix survives container restarts.

This does not change any existing routing or mTLS behavior yet. It only provides the infrastructure for future targeted exceptions that should trust the current public home IPs instead of `private_ranges`.

## Validation
- `docker compose config`
- `docker run --rm ... caddy validate --config /etc/caddy/Caddyfile` using `caddy:2.11.1`
