### PR TITLE
feat: Authentik über Caddy Reverse Proxy anbinden

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -101,6 +101,13 @@ dms.{$CADDY_SUBDOMAIN} {
         import logging_info
 }
 
+authentik.{$CADDY_SUBDOMAIN} {
+        import mTLS_required
+        encode gzip
+        reverse_proxy http://authentik-docker-authentik-server-1.network_backend_net:9000
+        import logging_info
+}
+
 # Uncomment this in addition with the import admin_redir statement allow access to the admin interface only from local networks
 (admin_redir) {
         @admin {

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Caddy reverse proxy docker-compose setup.
 
+## Authentik route
+
+The reverse proxy exposes authentik at `authentik.{$CADDY_SUBDOMAIN}` and forwards traffic to
+`authentik-docker-authentik-server-1.network_backend_net:9000`.
+
+The target service must be attached to `network_backend_net`.
+
 ## Environment
 
 Set `TELEGRAM_WEBHOOK_SECRET` to the same value used by the Scanservjs Telegram bot webhook. Caddy checks this value against the `X-Telegram-Bot-Api-Secret-Token` header and only bypasses mTLS for:


### PR DESCRIPTION
## Zusammenfassung

Dieser Pull Request ergänzt eine dedizierte Reverse-Proxy-Route für den Authentik-Server im bestehenden Caddy-Setup.

Ziel ist, dass Authentik über die bestehende Proxy-Infrastruktur unter einem eigenen Hostnamen erreichbar ist.

## Änderungen

- `Caddyfile`
  - Neuer Site-Block: `authentik.{$CADDY_SUBDOMAIN}`
  - Aktiviert bestehende Sicherheitsvorgaben:
    - `import mTLS_required`
    - `encode gzip`
  - Reverse Proxy Ziel:
    - `http://authentik-docker-authentik-server-1.network_backend_net:9000`
  - Logging über `import logging_info`

- `README.md`
  - Abschnitt `Authentik route` ergänzt
  - Dokumentiert Hostname und Zielcontainer
  - Hinweis ergänzt, dass der Zielservice am externen Docker-Netz `network_backend_net` hängen muss

## Betriebshinweise

- Voraussetzung: Der Authentik-Stack ist mit `network_backend_net` verbunden.
- DNS/Hosteintrag für `authentik.<deine-domain>` muss auf Caddy zeigen.
- Zugriff folgt den bestehenden mTLS-Regeln (`mTLS_required`).

## Validierung

- Compose-Rendering geprüft via `docker compose config` (lokal erfolgreich).