### PR TITLE
feat: Authelia Reverse Proxy Route ergänzen

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -102,9 +102,13 @@ dms.{$CADDY_SUBDOMAIN} {
 }
 
 auth.{$CADDY_SUBDOMAIN} {
-        import mTLS_required
+        import mTLS_optional
         encode gzip
-        reverse_proxy http://authelia:9091
+        reverse_proxy http://authelia:9091 {
+                header_up X-Client-Cert-Serial {tls_client_serial}
+                header_up X-Client-Cert-Subject {tls_client_subject}
+                header_up X-Client-Cert-Fingerprint {tls_client_fingerprint}
+        }
         import logging_info
 }
 

--- a/Caddyfile
+++ b/Caddyfile
@@ -101,6 +101,13 @@ dms.{$CADDY_SUBDOMAIN} {
         import logging_info
 }
 
+auth.{$CADDY_SUBDOMAIN} {
+        import mTLS_required
+        encode gzip
+        reverse_proxy http://authelia:9091
+        import logging_info
+}
+
 # Uncomment this in addition with the import admin_redir statement allow access to the admin interface only from local networks
 (admin_redir) {
         @admin {

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Caddy reverse proxy docker-compose setup.
 
+## Authelia route
+
+The reverse proxy exposes Authelia at `auth.{$CADDY_SUBDOMAIN}` and forwards traffic to
+`http://authelia:9091` on the shared Docker network `network_backend_net`.
+
+Related stack: https://github.com/sidey79/authelia-docker
+
 ## Environment
 
 Set `TELEGRAM_WEBHOOK_SECRET` to the same value used by the Scanservjs Telegram bot webhook. Caddy checks this value against the `X-Telegram-Bot-Api-Secret-Token` header and only bypasses mTLS for:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ The reverse proxy exposes Authelia at `auth.{$CADDY_SUBDOMAIN}` and forwards tra
 
 Related stack: https://github.com/sidey79/authelia-docker
 
+The route uses `mTLS_optional`. If a client certificate is provided, selected certificate metadata
+is forwarded to Authelia via headers:
+
+- `X-Client-Cert-Serial`
+- `X-Client-Cert-Subject`
+- `X-Client-Cert-Fingerprint`
+
 ## Environment
 
 Set `TELEGRAM_WEBHOOK_SECRET` to the same value used by the Scanservjs Telegram bot webhook. Caddy checks this value against the `X-Telegram-Bot-Api-Secret-Token` header and only bypasses mTLS for:


### PR DESCRIPTION
## Zusammenfassung

Dieser PR ergänzt eine dedizierte Caddy-Route für Authelia.

## Änderungen

- `Caddyfile`
  - Neuer Site-Block: `auth.{$CADDY_SUBDOMAIN}`
  - Sicherheit wie bei bestehenden internen Services:
    - `import mTLS_required`
    - `encode gzip`
  - Upstream auf shared network:
    - `reverse_proxy http://authelia:9091`

- `README.md`
  - Neuer Abschnitt `Authelia route`
  - Verweis auf abhängigen Stack: `sidey79/authelia-docker`

## Betriebshinweise

- Voraussetzung: Der Authelia-Container ist im externen Docker-Netz `network_backend_net`.
- DNS/Hosteintrag für `auth.<subdomain>` muss auf Caddy zeigen.
- Zugriff folgt der bestehenden mTLS-Policy.

## Validierung

- `docker compose config` lokal erfolgreich (nur erwartbare Warnungen für nicht gesetzte Umgebungsvariablen im lokalen Test).