### PR TITLE
Protect workflow UI with Authelia

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,3 +12,36 @@ jobs:
           path: ./
           recursive: true
           fix: false
+  caddyfile:
+    name: runner / caddyfile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+      - name: Prepare dummy CA files
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/caddy-ca/certs" "$RUNNER_TEMP/caddy-ca/private"
+          openssl genrsa -out "$RUNNER_TEMP/caddy-ca/private/caddy-intermediate.key" 2048
+          openssl req -x509 -new -key "$RUNNER_TEMP/caddy-ca/private/caddy-intermediate.key" \
+            -out "$RUNNER_TEMP/caddy-ca/certs/caddy-intermediate.crt" -days 1 \
+            -subj "/CN=Dummy Caddy Intermediate"
+          openssl genrsa -out "$RUNNER_TEMP/caddy-ca/private/blausee_ca.key" 2048
+          openssl req -x509 -new -key "$RUNNER_TEMP/caddy-ca/private/blausee_ca.key" \
+            -out "$RUNNER_TEMP/caddy-ca/certs/blausee_ca.crt" -days 1 \
+            -subj "/CN=Dummy Root CA"
+      - name: Validate Caddyfile
+        run: |
+          docker run --rm -u 0 \
+            -e CADDY_SUBDOMAIN=example.com \
+            -e CADDY_SUBDOMAIN2=example2.com \
+            -e CADDY_SUBDOMAIN3=example3.com \
+            -e CADDY_ADMIN_USER=admin \
+            -e CADDY_ADMIN_PASSWORD=secret \
+            -e TELEGRAM_WEBHOOK_SECRET=dummy \
+            -v "$GITHUB_WORKSPACE:/work" \
+            -v "$RUNNER_TEMP/caddy-ca/certs:/etc/ssl/ca/certs:ro" \
+            -v "$RUNNER_TEMP/caddy-ca/private:/etc/ssl/ca/private:ro" \
+            -w /work \
+            caddy:2.11.2 sh -lc 'caddy validate --config /work/Caddyfile'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,6 +33,7 @@ jobs:
             -subj "/CN=Dummy Root CA"
       - name: Validate Caddyfile
         run: |
+          CADDY_IMAGE="$(docker compose config --images caddy | head -n 1)"
           docker run --rm -u 0 \
             -e CADDY_SUBDOMAIN=example.com \
             -e CADDY_SUBDOMAIN2=example2.com \
@@ -44,4 +45,4 @@ jobs:
             -v "$RUNNER_TEMP/caddy-ca/certs:/etc/ssl/ca/certs:ro" \
             -v "$RUNNER_TEMP/caddy-ca/private:/etc/ssl/ca/private:ro" \
             -w /work \
-            caddy:2.11.2 sh -lc 'caddy validate --config /work/Caddyfile'
+            "$CADDY_IMAGE" sh -lc 'caddy validate --config /work/Caddyfile'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
             -subj "/CN=Dummy Root CA"
       - name: Validate Caddyfile
         run: |
-          CADDY_IMAGE="$(docker compose config --images caddy | head -n 1)"
+          CADDY_IMAGE="$(docker compose config --format json | jq -r '.services.caddy.image')"
           docker run --rm -u 0 \
             -e CADDY_SUBDOMAIN=example.com \
             -e CADDY_SUBDOMAIN2=example2.com \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,4 +45,4 @@ jobs:
             -v "$RUNNER_TEMP/caddy-ca/certs:/etc/ssl/ca/certs:ro" \
             -v "$RUNNER_TEMP/caddy-ca/private:/etc/ssl/ca/private:ro" \
             -w /work \
-            "$CADDY_IMAGE" sh -lc 'caddy validate --config /work/Caddyfile'
+            "$CADDY_IMAGE" sh -lc 'caddy validate --config /work/caddy/Caddyfile'

--- a/Caddyfile
+++ b/Caddyfile
@@ -65,6 +65,12 @@
                 }
         }
 }
+(authelia_forward_auth) {
+        forward_auth authelia:9091 {
+                uri /api/authz/forward-auth
+                copy_headers Remote-User Remote-Groups Remote-Email Remote-Name
+        }
+}
 (logging_info) {
         log {
                 level INFO
@@ -192,6 +198,9 @@ workflow.{$CADDY_SUBDOMAIN} {
         @workflowAssets {
                 path /assets/*
         }
+        @githubPrDashboardWebhook {
+                path /webhook/github-pr-dashboard /webhook/github-pr-dashboard/* /webhook-test/github-pr-dashboard /webhook-test/github-pr-dashboard/*
+        }
         @n8nWebHooks {
                 path /webhook/* /webhook-test/* /webhook-waiting/*
         }
@@ -206,6 +215,16 @@ workflow.{$CADDY_SUBDOMAIN} {
                         root * /srv/workflow
 
                         file_server
+                }
+                handle @githubPrDashboardWebhook {
+                        reverse_proxy https://n8n-n8n-1.network_backend_net:5678 {
+                                transport http {
+                                        tls_server_name n8n
+                                        tls_trust_pool file {
+                                                pem_file /etc/ssl/ca/certs/blausee_ca.crt
+                                        }
+                                }
+                        }
                 }
                 handle @telegramReissueWebhook {
                         reverse_proxy https://n8n-n8n-1.network_backend_net:5678 {
@@ -222,6 +241,17 @@ workflow.{$CADDY_SUBDOMAIN} {
                         respond "mTLS client certificate required" 403
                 }
                 handle @n8nWebHooks {
+                        reverse_proxy https://n8n-n8n-1.network_backend_net:5678 {
+                                transport http {
+                                        tls_server_name n8n
+                                        tls_trust_pool file {
+                                                pem_file /etc/ssl/ca/certs/blausee_ca.crt
+                                        }
+                                }
+                        }
+                }
+                handle {
+                        import authelia_forward_auth
                         reverse_proxy https://n8n-n8n-1.network_backend_net:5678 {
                                 transport http {
                                         tls_server_name n8n

--- a/Caddyfile
+++ b/Caddyfile
@@ -66,6 +66,7 @@
 	}
 }
 (authelia_forward_auth) {
+	request_header -Remote-*
 	forward_auth authelia:9091 {
 		uri /api/authz/forward-auth
 		copy_headers Remote-User Remote-Groups Remote-Email Remote-Name
@@ -75,6 +76,24 @@
 	log {
 		level INFO
 	}
+}
+(n8n_upstream) {
+	reverse_proxy https://n8n-n8n-1.network_backend_net:5678 {
+		transport http {
+			tls_server_name n8n
+			tls_trust_pool file {
+				pem_file /etc/ssl/ca/certs/blausee_ca.crt
+			}
+		}
+	}
+}
+(githubPrDashboardUi_base) {
+	method GET HEAD
+	path /webhook/github-pr-dashboard /webhook/github-pr-dashboard/*
+}
+(githubPrDashboardUi_mtls) {
+	import githubPrDashboardUi_base
+	expression {tls_client_subject} != null
 }
 #pi2 {
 #  tls internal
@@ -140,7 +159,7 @@ bitwarden.{$CADDY_SUBDOMAIN} {
 	# If you want to use FIDO2 WebAuthn, set X-Frame-Options to "SAMEORIGIN" or the Browser will block those requests
 	header / {
 		# Enable HTTP Strict Transport Security (HSTS)
-		Strict-Transport-Security "max-age=31536000;"
+			Strict-Transport-Security "max-age=31536000;"
 		# Disable cross-site filter (XSS)
 		X-XSS-Protection "0"
 		# Disallow the site to be rendered within a frame (clickjacking protection)
@@ -209,6 +228,12 @@ workflow.{$CADDY_SUBDOMAIN} {
 	@n8nWebHooks {
 		path /webhook/* /webhook-test/* /webhook-waiting/*
 	}
+	@githubPrDashboardUiMtls {
+		import githubPrDashboardUi_mtls
+	}
+	@githubPrDashboardUi {
+		import githubPrDashboardUi_base
+	}
 	# Allow Telegram to call only the Scanservjs token reissue webhook without mTLS.
 	@telegramReissueWebhook {
 		method POST
@@ -221,50 +246,28 @@ workflow.{$CADDY_SUBDOMAIN} {
 
 			file_server
 		}
+		handle @githubPrDashboardUiMtls {
+			import n8n_upstream
+		}
 		handle @githubPrDashboardUi {
 			import authelia_forward_auth
-			reverse_proxy https://n8n-n8n-1.network_backend_net:5678 {
-				transport http {
-					tls_server_name n8n
-					tls_trust_pool file {
-						pem_file /etc/ssl/ca/certs/blausee_ca.crt
-					}
-				}
-			}
+			import n8n_upstream
 		}
 		handle @githubPrDashboardWebhook {
-			reverse_proxy https://n8n-n8n-1.network_backend_net:5678 {
-				transport http {
-					tls_server_name n8n
-					tls_trust_pool file {
-						pem_file /etc/ssl/ca/certs/blausee_ca.crt
-					}
-				}
-			}
+			import n8n_upstream
 		}
 		handle @telegramReissueWebhook {
-			reverse_proxy https://n8n-n8n-1.network_backend_net:5678 {
-				transport http {
-					tls_server_name n8n
-					tls_trust_pool file {
-						pem_file /etc/ssl/ca/certs/blausee_ca.crt
-					}
-				}
-			}
+			import n8n_upstream
 		}
-		import missing_mTLS_cert
-		handle @missing_mTLS_cert {
+		@workflow_missing_mtls {
+			expression {tls_client_subject} == null
+			not path /webhook/github-pr-dashboard /webhook/github-pr-dashboard/*
+		}
+		handle @workflow_missing_mtls {
 			respond "mTLS client certificate required" 403
 		}
 		handle @n8nWebHooks {
-			reverse_proxy https://n8n-n8n-1.network_backend_net:5678 {
-				transport http {
-					tls_server_name n8n
-					tls_trust_pool file {
-						pem_file /etc/ssl/ca/certs/blausee_ca.crt
-					}
-				}
-			}
+			import n8n_upstream
 		}
 	}
 	import logging_info
@@ -276,12 +279,5 @@ n8n.{$CADDY_SUBDOMAIN3} {
 			ca blausee_ca
 		}
 	}
-	reverse_proxy https://n8n-n8n-1.network_backend_net:5678 {
-		transport http {
-			tls_server_name n8n
-			tls_trust_pool file {
-				pem_file /etc/ssl/ca/certs/blausee_ca.crt
-			}
-		}
-	}
+	import n8n_upstream
 }

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,80 +1,80 @@
 {
-        acme_ca https://acme.zerossl.com/v2/DV90
-        email sven@blausee.eu
-        pki {
-                ca blausee_ca {
-                        root {
-                                format pem_file
-                                cert /etc/ssl/ca/certs/blausee_ca.crt
-                        }
-                        intermediate {
-                                format pem_file
-                                cert /etc/ssl/ca/certs/caddy-intermediate.crt
-                                key /etc/ssl/ca/private/caddy-intermediate.key
-                        }
-                }
-        }
+	acme_ca https://acme.zerossl.com/v2/DV90
+	email sven@blausee.eu
+	pki {
+		ca blausee_ca {
+			root {
+				format pem_file
+				cert /etc/ssl/ca/certs/blausee_ca.crt
+			}
+			intermediate {
+				format pem_file
+				cert /etc/ssl/ca/certs/caddy-intermediate.crt
+				key /etc/ssl/ca/private/caddy-intermediate.key
+			}
+		}
+	}
 }
 
 (missing_mTLS_cert) {
-        @missing_mTLS_cert {
-                expression {tls_client_subject} == null
-        }
+	@missing_mTLS_cert {
+		expression {tls_client_subject} == null
+	}
 }
 
 (valid_mTLS_cert) {
-        @valid_mTLS_cert {
-                expression {tls_client_serial} == "3"
-        }
+	@valid_mTLS_cert {
+		expression {tls_client_serial} == "3"
+	}
 }
 
 (admin_user) {
-        {$CADDY_ADMIN_USER} {$CADDY_ADMIN_PASSWORD}
+	{$CADDY_ADMIN_USER} {$CADDY_ADMIN_PASSWORD}
 }
 
 (private_auth) {
-        import missing_mTLS_cert
-        basicauth @missing_mTLS_cert {
-                import admin_user
-        }
+	import missing_mTLS_cert
+	basicauth @missing_mTLS_cert {
+		import admin_user
+	}
 }
 
 (mTLS_required) {
-        tls {
-                client_auth {
-                        mode require_and_verify
-                        trust_pool file {
-                                pem_file /etc/ssl/ca/certs/blausee_ca.crt
-                        }
-                }
-        }
+	tls {
+		client_auth {
+			mode require_and_verify
+			trust_pool file {
+				pem_file /etc/ssl/ca/certs/blausee_ca.crt
+			}
+		}
+	}
 }
 
 (local_ip_ranges) {
-        not remote_ip 10.2.11.0/24
+	not remote_ip 10.2.11.0/24
 }
 
 # use this import if you want to be able to fallback to basic auth
 (mTLS_optional) {
-        tls {
-                client_auth {
-                        mode verify_if_given
-                        trust_pool file {
-                                pem_file /etc/ssl/ca/certs/blausee_ca.crt
-                        }
-                }
-        }
+	tls {
+		client_auth {
+			mode verify_if_given
+			trust_pool file {
+				pem_file /etc/ssl/ca/certs/blausee_ca.crt
+			}
+		}
+	}
 }
 (authelia_forward_auth) {
-        forward_auth authelia:9091 {
-                uri /api/authz/forward-auth
-                copy_headers Remote-User Remote-Groups Remote-Email Remote-Name
-        }
+	forward_auth authelia:9091 {
+		uri /api/authz/forward-auth
+		copy_headers Remote-User Remote-Groups Remote-Email Remote-Name
+	}
 }
 (logging_info) {
-        log {
-                level INFO
-        }
+	log {
+		level INFO
+	}
 }
 #pi2 {
 #  tls internal
@@ -86,80 +86,80 @@
 
 
 fhem.{$CADDY_SUBDOMAIN} {
-        import mTLS_required
-        encode gzip
-        reverse_proxy https://fhem-fhem-1.network_backend_net:8083 {
-                transport http {
-                        tls_server_name zeus.fritz.box
-                        tls_trust_pool file {
-                                pem_file /etc/ssl/ca/certs/blausee_ca.crt
-                        }
-                }
-        }
+	import mTLS_required
+	encode gzip
+	reverse_proxy https://fhem-fhem-1.network_backend_net:8083 {
+		transport http {
+			tls_server_name zeus.fritz.box
+			tls_trust_pool file {
+				pem_file /etc/ssl/ca/certs/blausee_ca.crt
+			}
+		}
+	}
 
-        import logging_info
+	import logging_info
 }
 
 dms.{$CADDY_SUBDOMAIN} {
-        import mTLS_required
-        encode gzip
-        reverse_proxy http://paperless-ngx-webserver-1.network_backend_net:8000
-        import logging_info
+	import mTLS_required
+	encode gzip
+	reverse_proxy http://paperless-ngx-webserver-1.network_backend_net:8000
+	import logging_info
 }
 
 auth.{$CADDY_SUBDOMAIN} {
-        import mTLS_optional
-        encode gzip
-        reverse_proxy http://authelia:9091 {
-                header_up X-Client-Cert-Serial {tls_client_serial}
-                header_up X-Client-Cert-Subject {tls_client_subject}
-                header_up X-Client-Cert-Fingerprint {tls_client_fingerprint}
-        }
-        import logging_info
+	import mTLS_optional
+	encode gzip
+	reverse_proxy http://authelia:9091 {
+		header_up X-Client-Cert-Serial {tls_client_serial}
+		header_up X-Client-Cert-Subject {tls_client_subject}
+		header_up X-Client-Cert-Fingerprint {tls_client_fingerprint}
+	}
+	import logging_info
 }
 
 # Uncomment this in addition with the import admin_redir statement allow access to the admin interface only from local networks
 (admin_redir) {
-        @admin {
-                path /admin*
-                not remote_ip private_ranges
-        }
-        redir @admin /
+	@admin {
+		path /admin*
+		not remote_ip private_ranges
+	}
+	redir @admin /
 }
 
 bitwarden.{$CADDY_SUBDOMAIN} {
-        encode gzip
-        import admin_redir
-        route {
-                @tasks path /api/tasks
-                handle @tasks {
-                        header Content-Type application/json
-                        respond `{"data":[],"object":"list"}` 200
-                }
-        }
-        # If you want to use FIDO2 WebAuthn, set X-Frame-Options to "SAMEORIGIN" or the Browser will block those requests
-        header / {
-                # Enable HTTP Strict Transport Security (HSTS)
-                Strict-Transport-Security "max-age=31536000;"
-                # Disable cross-site filter (XSS)
-                X-XSS-Protection "0"
-                # Disallow the site to be rendered within a frame (clickjacking protection)
-                X-Frame-Options "DENY"
-                # Prevent search engines from indexing (optional)
-                X-Robots-Tag "noindex, nofollow"
-                # Disallow sniffing of X-Content-Type-Options
-                X-Content-Type-Options "nosniff"
-                # Server name removing
-                -Server
-                # Remove X-Powered-By though this shouldnt be an issue, better opsec to remove
-                -X-Powered-By
-                # Remove Last-Modified because etag is the same and is as effective
-                -Last-Modified
-        }
-        reverse_proxy http://bitwarden.network_backend_net:8889 {
-                header_up X-Real-IP {remote_host}
-        }
-        import logging_info
+	encode gzip
+	import admin_redir
+	route {
+		@tasks path /api/tasks
+		handle @tasks {
+			header Content-Type application/json
+			respond `{"data":[],"object":"list"}` 200
+		}
+	}
+	# If you want to use FIDO2 WebAuthn, set X-Frame-Options to "SAMEORIGIN" or the Browser will block those requests
+	header / {
+		# Enable HTTP Strict Transport Security (HSTS)
+		Strict-Transport-Security "max-age=31536000;"
+		# Disable cross-site filter (XSS)
+		X-XSS-Protection "0"
+		# Disallow the site to be rendered within a frame (clickjacking protection)
+		X-Frame-Options "DENY"
+		# Prevent search engines from indexing (optional)
+		X-Robots-Tag "noindex, nofollow"
+		# Disallow sniffing of X-Content-Type-Options
+		X-Content-Type-Options "nosniff"
+		# Server name removing
+		-Server
+		# Remove X-Powered-By though this shouldnt be an issue, better opsec to remove
+		-X-Powered-By
+		# Remove Last-Modified because etag is the same and is as effective
+		-Last-Modified
+	}
+	reverse_proxy http://bitwarden.network_backend_net:8889 {
+		header_up X-Real-IP {remote_host}
+	}
+	import logging_info
 }
 
 # caddy.{$CADDY_SUBDOMAIN2} {
@@ -174,109 +174,109 @@ bitwarden.{$CADDY_SUBDOMAIN} {
 # }
 
 ui.{$CADDY_SUBDOMAIN} {
-        import mTLS_required
-        root * /srv/ftui
-        rewrite /images/* /fhem{uri}
+	import mTLS_required
+	root * /srv/ftui
+	rewrite /images/* /fhem{uri}
 
-        reverse_proxy /fhem/images/* https://fhem-fhem-1.network_backend_net:8088 {
-                transport http {
-                        tls_server_name zeus.fritz.box
-                        tls_trust_pool file {
-                                pem_file /etc/ssl/ca/certs/blausee_ca.crt
-                        }
-                }
-        }
-        file_server
-        #import logging_info
-        log {
-                level DEBUG
-        }
+	reverse_proxy /fhem/images/* https://fhem-fhem-1.network_backend_net:8088 {
+		transport http {
+			tls_server_name zeus.fritz.box
+			tls_trust_pool file {
+				pem_file /etc/ssl/ca/certs/blausee_ca.crt
+			}
+		}
+	}
+	file_server
+	#import logging_info
+	log {
+		level DEBUG
+	}
 }
 
 workflow.{$CADDY_SUBDOMAIN} {
-        import mTLS_optional
-        @workflowAssets {
-                path /assets/*
-        }
-        @githubPrDashboardWebhook {
-                path /webhook/github-pr-dashboard /webhook/github-pr-dashboard/* /webhook-test/github-pr-dashboard /webhook-test/github-pr-dashboard/*
-        }
-        @n8nWebHooks {
-                path /webhook/* /webhook-test/* /webhook-waiting/*
-        }
-        # Allow Telegram to call only the Scanservjs token reissue webhook without mTLS.
-        @telegramReissueWebhook {
-                method POST
-                header X-Telegram-Bot-Api-Secret-Token {$TELEGRAM_WEBHOOK_SECRET}
-                path /webhook/scanservjs/telegram/reissue /webhook-test/scanservjs/telegram/reissue
-        }
-        route {
-                handle @workflowAssets {
-                        root * /srv/workflow
+	import mTLS_optional
+	@workflowAssets {
+		path /assets/*
+	}
+	@githubPrDashboardWebhook {
+		path /webhook/github-pr-dashboard /webhook/github-pr-dashboard/* /webhook-test/github-pr-dashboard /webhook-test/github-pr-dashboard/*
+	}
+	@n8nWebHooks {
+		path /webhook/* /webhook-test/* /webhook-waiting/*
+	}
+	# Allow Telegram to call only the Scanservjs token reissue webhook without mTLS.
+	@telegramReissueWebhook {
+		method POST
+		header X-Telegram-Bot-Api-Secret-Token {$TELEGRAM_WEBHOOK_SECRET}
+		path /webhook/scanservjs/telegram/reissue /webhook-test/scanservjs/telegram/reissue
+	}
+	route {
+		handle @workflowAssets {
+			root * /srv/workflow
 
-                        file_server
-                }
-                handle @githubPrDashboardWebhook {
-                        reverse_proxy https://n8n-n8n-1.network_backend_net:5678 {
-                                transport http {
-                                        tls_server_name n8n
-                                        tls_trust_pool file {
-                                                pem_file /etc/ssl/ca/certs/blausee_ca.crt
-                                        }
-                                }
-                        }
-                }
-                handle @telegramReissueWebhook {
-                        reverse_proxy https://n8n-n8n-1.network_backend_net:5678 {
-                                transport http {
-                                        tls_server_name n8n
-                                        tls_trust_pool file {
-                                                pem_file /etc/ssl/ca/certs/blausee_ca.crt
-                                        }
-                                }
-                        }
-                }
-                import missing_mTLS_cert
-                handle @missing_mTLS_cert {
-                        respond "mTLS client certificate required" 403
-                }
-                handle @n8nWebHooks {
-                        reverse_proxy https://n8n-n8n-1.network_backend_net:5678 {
-                                transport http {
-                                        tls_server_name n8n
-                                        tls_trust_pool file {
-                                                pem_file /etc/ssl/ca/certs/blausee_ca.crt
-                                        }
-                                }
-                        }
-                }
-                handle {
-                        import authelia_forward_auth
-                        reverse_proxy https://n8n-n8n-1.network_backend_net:5678 {
-                                transport http {
-                                        tls_server_name n8n
-                                        tls_trust_pool file {
-                                                pem_file /etc/ssl/ca/certs/blausee_ca.crt
-                                        }
-                                }
-                        }
-                }
-        }
-        import logging_info
+			file_server
+		}
+		handle @githubPrDashboardWebhook {
+			reverse_proxy https://n8n-n8n-1.network_backend_net:5678 {
+				transport http {
+					tls_server_name n8n
+					tls_trust_pool file {
+						pem_file /etc/ssl/ca/certs/blausee_ca.crt
+					}
+				}
+			}
+		}
+		handle @telegramReissueWebhook {
+			reverse_proxy https://n8n-n8n-1.network_backend_net:5678 {
+				transport http {
+					tls_server_name n8n
+					tls_trust_pool file {
+						pem_file /etc/ssl/ca/certs/blausee_ca.crt
+					}
+				}
+			}
+		}
+		import missing_mTLS_cert
+		handle @missing_mTLS_cert {
+			respond "mTLS client certificate required" 403
+		}
+		handle @n8nWebHooks {
+			reverse_proxy https://n8n-n8n-1.network_backend_net:5678 {
+				transport http {
+					tls_server_name n8n
+					tls_trust_pool file {
+						pem_file /etc/ssl/ca/certs/blausee_ca.crt
+					}
+				}
+			}
+		}
+		handle {
+			import authelia_forward_auth
+			reverse_proxy https://n8n-n8n-1.network_backend_net:5678 {
+				transport http {
+					tls_server_name n8n
+					tls_trust_pool file {
+						pem_file /etc/ssl/ca/certs/blausee_ca.crt
+					}
+				}
+			}
+		}
+	}
+	import logging_info
 }
 
 n8n.{$CADDY_SUBDOMAIN3} {
-        tls {
-                issuer internal {
-                        ca blausee_ca
-                }
-        }
-        reverse_proxy https://n8n-n8n-1.network_backend_net:5678 {
-                transport http {
-                        tls_server_name n8n
-                        tls_trust_pool file {
-                                pem_file /etc/ssl/ca/certs/blausee_ca.crt
-                        }
-                }
-        }
+	tls {
+		issuer internal {
+			ca blausee_ca
+		}
+	}
+	reverse_proxy https://n8n-n8n-1.network_backend_net:5678 {
+		transport http {
+			tls_server_name n8n
+			tls_trust_pool file {
+				pem_file /etc/ssl/ca/certs/blausee_ca.crt
+			}
+		}
+	}
 }

--- a/Caddyfile
+++ b/Caddyfile
@@ -87,14 +87,6 @@
 		}
 	}
 }
-(githubPrDashboardUi_base) {
-	method GET HEAD
-	path /webhook/github-pr-dashboard /webhook/github-pr-dashboard/*
-}
-(githubPrDashboardUi_mtls) {
-	import githubPrDashboardUi_base
-	expression {tls_client_subject} != null
-}
 #pi2 {
 #  tls internal
 #  import mTLS_optional
@@ -115,7 +107,6 @@ fhem.{$CADDY_SUBDOMAIN} {
 			}
 		}
 	}
-
 	import logging_info
 }
 
@@ -159,7 +150,7 @@ bitwarden.{$CADDY_SUBDOMAIN} {
 	# If you want to use FIDO2 WebAuthn, set X-Frame-Options to "SAMEORIGIN" or the Browser will block those requests
 	header / {
 		# Enable HTTP Strict Transport Security (HSTS)
-			Strict-Transport-Security "max-age=31536000;"
+		Strict-Transport-Security "max-age=31536000;"
 		# Disable cross-site filter (XSS)
 		X-XSS-Protection "0"
 		# Disallow the site to be rendered within a frame (clickjacking protection)
@@ -217,22 +208,19 @@ workflow.{$CADDY_SUBDOMAIN} {
 	@workflowAssets {
 		path /assets/*
 	}
-	@githubPrDashboardUi {
+	@githubPrDashboardUiMtls {
 		method GET HEAD
-		path /webhook/github-pr-dashboard /webhook/github-pr-dashboard/*
+		path /webhook/github-pr-dashboard /webhook/github-pr-dashboard/* /webhook-test/github-pr-dashboard /webhook-test/github-pr-dashboard/*
+		expression {tls_client_subject} != null
+	}
+	@githubPrDashboardUiAuthelia {
+		method GET HEAD
+		path /webhook/github-pr-dashboard /webhook/github-pr-dashboard/* /webhook-test/github-pr-dashboard /webhook-test/github-pr-dashboard/*
+		expression {tls_client_subject} == null
 	}
 	@githubPrDashboardWebhook {
 		method POST
 		path /webhook/github-pr-dashboard /webhook/github-pr-dashboard/* /webhook-test/github-pr-dashboard /webhook-test/github-pr-dashboard/*
-	}
-	@n8nWebHooks {
-		path /webhook/* /webhook-test/* /webhook-waiting/*
-	}
-	@githubPrDashboardUiMtls {
-		import githubPrDashboardUi_mtls
-	}
-	@githubPrDashboardUi {
-		import githubPrDashboardUi_base
 	}
 	# Allow Telegram to call only the Scanservjs token reissue webhook without mTLS.
 	@telegramReissueWebhook {
@@ -240,33 +228,37 @@ workflow.{$CADDY_SUBDOMAIN} {
 		header X-Telegram-Bot-Api-Secret-Token {$TELEGRAM_WEBHOOK_SECRET}
 		path /webhook/scanservjs/telegram/reissue /webhook-test/scanservjs/telegram/reissue
 	}
+	@n8nWebHooksMtls {
+		path /webhook/* /webhook-test/* /webhook-waiting/*
+		expression {tls_client_subject} != null
+	}
+	@n8nWebHooksAuthelia {
+		path /webhook/* /webhook-test/* /webhook-waiting/*
+		expression {tls_client_subject} == null
+	}
 	route {
 		handle @workflowAssets {
 			root * /srv/workflow
-
 			file_server
+		}
+		handle @githubPrDashboardWebhook {
+			import n8n_upstream
 		}
 		handle @githubPrDashboardUiMtls {
 			import n8n_upstream
 		}
-		handle @githubPrDashboardUi {
+		handle @githubPrDashboardUiAuthelia {
 			import authelia_forward_auth
-			import n8n_upstream
-		}
-		handle @githubPrDashboardWebhook {
 			import n8n_upstream
 		}
 		handle @telegramReissueWebhook {
 			import n8n_upstream
 		}
-		@workflow_missing_mtls {
-			expression {tls_client_subject} == null
-			not path /webhook/github-pr-dashboard /webhook/github-pr-dashboard/*
+		handle @n8nWebHooksMtls {
+			import n8n_upstream
 		}
-		handle @workflow_missing_mtls {
-			respond "mTLS client certificate required" 403
-		}
-		handle @n8nWebHooks {
+		handle @n8nWebHooksAuthelia {
+			import authelia_forward_auth
 			import n8n_upstream
 		}
 	}

--- a/Caddyfile
+++ b/Caddyfile
@@ -65,6 +65,12 @@
 		}
 	}
 }
+(authelia_forward_auth) {
+	forward_auth authelia:9091 {
+		uri /api/authz/forward-auth
+		copy_headers Remote-User Remote-Groups Remote-Email Remote-Name
+	}
+}
 (logging_info) {
 	log {
 		level INFO
@@ -192,7 +198,12 @@ workflow.{$CADDY_SUBDOMAIN} {
 	@workflowAssets {
 		path /assets/*
 	}
+	@githubPrDashboardUi {
+		method GET HEAD
+		path /webhook/github-pr-dashboard /webhook/github-pr-dashboard/*
+	}
 	@githubPrDashboardWebhook {
+		method POST
 		path /webhook/github-pr-dashboard /webhook/github-pr-dashboard/* /webhook-test/github-pr-dashboard /webhook-test/github-pr-dashboard/*
 	}
 	@n8nWebHooks {
@@ -209,6 +220,17 @@ workflow.{$CADDY_SUBDOMAIN} {
 			root * /srv/workflow
 
 			file_server
+		}
+		handle @githubPrDashboardUi {
+			import authelia_forward_auth
+			reverse_proxy https://n8n-n8n-1.network_backend_net:5678 {
+				transport http {
+					tls_server_name n8n
+					tls_trust_pool file {
+						pem_file /etc/ssl/ca/certs/blausee_ca.crt
+					}
+				}
+			}
 		}
 		handle @githubPrDashboardWebhook {
 			reverse_proxy https://n8n-n8n-1.network_backend_net:5678 {

--- a/Caddyfile
+++ b/Caddyfile
@@ -65,12 +65,6 @@
 		}
 	}
 }
-(authelia_forward_auth) {
-	forward_auth authelia:9091 {
-		uri /api/authz/forward-auth
-		copy_headers Remote-User Remote-Groups Remote-Email Remote-Name
-	}
-}
 (logging_info) {
 	log {
 		level INFO
@@ -241,17 +235,6 @@ workflow.{$CADDY_SUBDOMAIN} {
 			respond "mTLS client certificate required" 403
 		}
 		handle @n8nWebHooks {
-			reverse_proxy https://n8n-n8n-1.network_backend_net:5678 {
-				transport http {
-					tls_server_name n8n
-					tls_trust_pool file {
-						pem_file /etc/ssl/ca/certs/blausee_ca.crt
-					}
-				}
-			}
-		}
-		handle {
-			import authelia_forward_auth
 			reverse_proxy https://n8n-n8n-1.network_backend_net:5678 {
 				transport http {
 					tls_server_name n8n

--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ The reverse proxy exposes Authelia at `auth.{$CADDY_SUBDOMAIN}` and forwards tra
 
 Related stack: https://github.com/sidey79/authelia-docker
 
-The route uses `mTLS_optional`. If a client certificate is provided, selected certificate metadata
-is forwarded to Authelia via headers:
+The route uses `mTLS_optional`. The browser-facing n8n UI is then protected with Authelia forward
+auth. The GitHub webhook path `/webhook/github-pr-dashboard` stays exempt so GitHub can still call
+it directly. If a client certificate is provided, selected certificate metadata is forwarded to
+Authelia via headers:
 
 - `X-Client-Cert-Serial`
 - `X-Client-Cert-Subject`
@@ -23,7 +25,8 @@ Set `TELEGRAM_WEBHOOK_SECRET` to the same value used by the Scanservjs Telegram 
 - `POST /webhook/scanservjs/telegram/reissue`
 - `POST /webhook-test/scanservjs/telegram/reissue`
 
-All other `workflow.*` paths remain protected by the existing mTLS policy.
+All other `workflow.*` paths remain protected by the existing mTLS policy and, for the browser UI,
+by Authelia forward auth.
 
 `docker compose up` starts a one-shot `fetch-workflow-assets` service before Caddy. It downloads `github-pr-dashboard.css` from `sidey79/n8n_wf_build` into `site/workflow/assets/`.
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ The reverse proxy exposes Authelia at `auth.{$CADDY_SUBDOMAIN}` and forwards tra
 Related stack: https://github.com/sidey79/authelia-docker
 
 The route uses `mTLS_optional`. The workflow host does not expose the n8n editor or any generic
-backend path. It only serves the local workflow asset store from `/assets/*` and forwards the
-explicit webhook paths to n8n. The GitHub webhook path `/webhook/github-pr-dashboard` stays exempt
-so GitHub can still call it directly. If a client certificate is provided, selected certificate
-metadata is forwarded to Authelia via headers:
+backend path. It only serves the local workflow asset store from `/assets/*`, protects the browser
+UI for `/webhook/github-pr-dashboard` with Authelia, and forwards the `POST` webhook request to
+n8n. If a client certificate is provided, selected certificate metadata is forwarded to Authelia
+via headers:
 
 - `X-Client-Cert-Serial`
 - `X-Client-Cert-Subject`

--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ The reverse proxy exposes Authelia at `auth.{$CADDY_SUBDOMAIN}` and forwards tra
 
 Related stack: https://github.com/sidey79/authelia-docker
 
-The route uses `mTLS_optional`. The browser-facing n8n UI is then protected with Authelia forward
-auth. The GitHub webhook path `/webhook/github-pr-dashboard` stays exempt so GitHub can still call
-it directly. If a client certificate is provided, selected certificate metadata is forwarded to
-Authelia via headers:
+The route uses `mTLS_optional`. The workflow host does not expose the n8n editor or any generic
+backend path. It only serves the local workflow asset store from `/assets/*` and forwards the
+explicit webhook paths to n8n. The GitHub webhook path `/webhook/github-pr-dashboard` stays exempt
+so GitHub can still call it directly. If a client certificate is provided, selected certificate
+metadata is forwarded to Authelia via headers:
 
 - `X-Client-Cert-Serial`
 - `X-Client-Cert-Subject`
@@ -25,8 +26,7 @@ Set `TELEGRAM_WEBHOOK_SECRET` to the same value used by the Scanservjs Telegram 
 - `POST /webhook/scanservjs/telegram/reissue`
 - `POST /webhook-test/scanservjs/telegram/reissue`
 
-All other `workflow.*` paths remain protected by the existing mTLS policy and, for the browser UI,
-by Authelia forward auth.
+All other `workflow.*` paths remain protected by the existing mTLS policy.
 
 `docker compose up` starts a one-shot `fetch-workflow-assets` service before Caddy. It downloads `github-pr-dashboard.css` from `sidey79/n8n_wf_build` into `site/workflow/assets/`.
 

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -208,6 +208,12 @@ workflow.{$CADDY_SUBDOMAIN} {
 	@workflowAssets {
 		path /assets/*
 	}
+	# Allow Telegram to call only the Scanservjs token reissue webhook without mTLS.
+	@telegramReissueWebhook {
+		method POST
+		header X-Telegram-Bot-Api-Secret-Token {$TELEGRAM_WEBHOOK_SECRET}
+		path /webhook/scanservjs/telegram/reissue /webhook-test/scanservjs/telegram/reissue
+	}
 	@githubPrDashboardUiMtls {
 		method GET HEAD
 		path /webhook/github-pr-dashboard /webhook/github-pr-dashboard/* /webhook-test/github-pr-dashboard /webhook-test/github-pr-dashboard/*
@@ -222,24 +228,23 @@ workflow.{$CADDY_SUBDOMAIN} {
 		method POST
 		path /webhook/github-pr-dashboard /webhook/github-pr-dashboard/* /webhook-test/github-pr-dashboard /webhook-test/github-pr-dashboard/*
 	}
-	# Allow Telegram to call only the Scanservjs token reissue webhook without mTLS.
-	@telegramReissueWebhook {
-		method POST
-		header X-Telegram-Bot-Api-Secret-Token {$TELEGRAM_WEBHOOK_SECRET}
-		path /webhook/scanservjs/telegram/reissue /webhook-test/scanservjs/telegram/reissue
-	}
-	@n8nWebHooksMtls {
-		path /webhook/* /webhook-test/* /webhook-waiting/*
+	@webhooksMtls {
+		path /webhook/* /webhook-test/*
+		not path /webhook/github-pr-dashboard /webhook/github-pr-dashboard/* /webhook-test/github-pr-dashboard /webhook-test/github-pr-dashboard/*
 		expression {tls_client_subject} != null
 	}
-	@n8nWebHooksAuthelia {
-		path /webhook/* /webhook-test/* /webhook-waiting/*
+	@webhooksAuthelia {
+		path /webhook/* /webhook-test/*
+		not path /webhook/github-pr-dashboard /webhook/github-pr-dashboard/* /webhook-test/github-pr-dashboard /webhook-test/github-pr-dashboard/*
 		expression {tls_client_subject} == null
 	}
 	route {
 		handle @workflowAssets {
 			root * /srv/workflow
 			file_server
+		}
+		handle @telegramReissueWebhook {
+			import n8n_upstream
 		}
 		handle @githubPrDashboardWebhook {
 			import n8n_upstream
@@ -251,13 +256,10 @@ workflow.{$CADDY_SUBDOMAIN} {
 			import authelia_forward_auth
 			import n8n_upstream
 		}
-		handle @telegramReissueWebhook {
+		handle @webhooksMtls {
 			import n8n_upstream
 		}
-		handle @n8nWebHooksMtls {
-			import n8n_upstream
-		}
-		handle @n8nWebHooksAuthelia {
+		handle @webhooksAuthelia {
 			import authelia_forward_auth
 			import n8n_upstream
 		}

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -18,7 +18,7 @@
 
 (missing_mTLS_cert) {
 	@missing_mTLS_cert {
-		expression {tls_client_subject} == null
+		expression {tls_client_subject} == ""
 	}
 }
 
@@ -217,22 +217,22 @@ workflow.{$CADDY_SUBDOMAIN} {
 	@githubPrDashboardUiMtls {
 		method GET HEAD POST
 		path /webhook/github-pr-dashboard /webhook/github-pr-dashboard/* /webhook-test/github-pr-dashboard /webhook-test/github-pr-dashboard/*
-		expression {tls_client_subject} != null
+		expression {tls_client_subject} != ""
 	}
 	@githubPrDashboardUiAuthelia {
 		method GET HEAD POST
 		path /webhook/github-pr-dashboard /webhook/github-pr-dashboard/* /webhook-test/github-pr-dashboard /webhook-test/github-pr-dashboard/*
-		expression {tls_client_subject} == null
+		expression {tls_client_subject} == ""
 	}
 	@webhooksMtls {
 		path /webhook/* /webhook-test/*
 		not path /webhook/github-pr-dashboard /webhook/github-pr-dashboard/* /webhook-test/github-pr-dashboard /webhook-test/github-pr-dashboard/*
-		expression {tls_client_subject} != null
+		expression {tls_client_subject} != ""
 	}
 	@webhooksAuthelia {
 		path /webhook/* /webhook-test/*
 		not path /webhook/github-pr-dashboard /webhook/github-pr-dashboard/* /webhook-test/github-pr-dashboard /webhook-test/github-pr-dashboard/*
-		expression {tls_client_subject} == null
+		expression {tls_client_subject} == ""
 	}
 	route {
 		handle @workflowAssets {

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -214,24 +214,12 @@ workflow.{$CADDY_SUBDOMAIN} {
 		header X-Telegram-Bot-Api-Secret-Token {$TELEGRAM_WEBHOOK_SECRET}
 		path /webhook/scanservjs/telegram/reissue /webhook-test/scanservjs/telegram/reissue
 	}
-	@githubPrDashboardUiMtls {
-		method GET HEAD POST
-		path /webhook/github-pr-dashboard /webhook/github-pr-dashboard/* /webhook-test/github-pr-dashboard /webhook-test/github-pr-dashboard/*
-		expression {tls_client_subject} != ""
-	}
-	@githubPrDashboardUiAuthelia {
-		method GET HEAD POST
-		path /webhook/github-pr-dashboard /webhook/github-pr-dashboard/* /webhook-test/github-pr-dashboard /webhook-test/github-pr-dashboard/*
-		expression {tls_client_subject} == ""
-	}
 	@webhooksMtls {
 		path /webhook/* /webhook-test/*
-		not path /webhook/github-pr-dashboard /webhook/github-pr-dashboard/* /webhook-test/github-pr-dashboard /webhook-test/github-pr-dashboard/*
 		expression {tls_client_subject} != ""
 	}
 	@webhooksAuthelia {
 		path /webhook/* /webhook-test/*
-		not path /webhook/github-pr-dashboard /webhook/github-pr-dashboard/* /webhook-test/github-pr-dashboard /webhook-test/github-pr-dashboard/*
 		expression {tls_client_subject} == ""
 	}
 	route {
@@ -240,13 +228,6 @@ workflow.{$CADDY_SUBDOMAIN} {
 			file_server
 		}
 		handle @telegramReissueWebhook {
-			import n8n_upstream
-		}
-		handle @githubPrDashboardUiMtls {
-			import n8n_upstream
-		}
-		handle @githubPrDashboardUiAuthelia {
-			import authelia_forward_auth
 			import n8n_upstream
 		}
 		handle @webhooksMtls {

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -79,7 +79,6 @@
 }
 (n8n_upstream) {
 	reverse_proxy https://n8n-n8n-1.network_backend_net:5678 {
-		header_up -X-Client-Cert-*
 		header_up X-Client-Cert-Subject {tls_client_subject}
 		header_up X-Client-Cert-Serial {tls_client_serial}
 		header_up X-Client-Cert-Fingerprint {tls_client_fingerprint}

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -79,6 +79,10 @@
 }
 (n8n_upstream) {
 	reverse_proxy https://n8n-n8n-1.network_backend_net:5678 {
+		header_up -X-Client-Cert-*
+		header_up X-Client-Cert-Subject {tls_client_subject}
+		header_up X-Client-Cert-Serial {tls_client_serial}
+		header_up X-Client-Cert-Fingerprint {tls_client_fingerprint}
 		transport http {
 			tls_server_name n8n
 			tls_trust_pool file {

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -215,18 +215,14 @@ workflow.{$CADDY_SUBDOMAIN} {
 		path /webhook/scanservjs/telegram/reissue /webhook-test/scanservjs/telegram/reissue
 	}
 	@githubPrDashboardUiMtls {
-		method GET HEAD
+		method GET HEAD POST
 		path /webhook/github-pr-dashboard /webhook/github-pr-dashboard/* /webhook-test/github-pr-dashboard /webhook-test/github-pr-dashboard/*
 		expression {tls_client_subject} != null
 	}
 	@githubPrDashboardUiAuthelia {
-		method GET HEAD
+		method GET HEAD POST
 		path /webhook/github-pr-dashboard /webhook/github-pr-dashboard/* /webhook-test/github-pr-dashboard /webhook-test/github-pr-dashboard/*
 		expression {tls_client_subject} == null
-	}
-	@githubPrDashboardWebhook {
-		method POST
-		path /webhook/github-pr-dashboard /webhook/github-pr-dashboard/* /webhook-test/github-pr-dashboard /webhook-test/github-pr-dashboard/*
 	}
 	@webhooksMtls {
 		path /webhook/* /webhook-test/*
@@ -244,9 +240,6 @@ workflow.{$CADDY_SUBDOMAIN} {
 			file_server
 		}
 		handle @telegramReissueWebhook {
-			import n8n_upstream
-		}
-		handle @githubPrDashboardWebhook {
 			import n8n_upstream
 		}
 		handle @githubPrDashboardUiMtls {

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -66,7 +66,6 @@
 	}
 }
 (authelia_forward_auth) {
-	request_header -Remote-*
 	forward_auth authelia:9091 {
 		uri /api/authz/forward-auth
 		copy_headers Remote-User Remote-Groups Remote-Email Remote-Name

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       fetch-workflow-assets:
         condition: service_completed_successfully
     volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile
+      - ./caddy:/etc/caddy
       - ./site:/srv
       - /opt/docker/caddy/data:/data
       - /opt/docker/caddy/caddy_config:/config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,12 +15,12 @@ services:
       - /opt/docker/rootca/intermediate/caddy-intermediate.crt.pem:/etc/ssl/ca/certs/caddy-intermediate.crt
       - /opt/docker/rootca/intermediate/caddy-intermediate.key.pem:/etc/ssl/ca/private/caddy-intermediate.key
     environment:
-      CADDY_SUBDOMAIN: $CADDY_SUBDOMAIN
-      CADDY_SUBDOMAIN2: $CADDY_SUBDOMAIN2
-      CADDY_SUBDOMAIN3: $CADDY_SUBDOMAIN3
-      CADDY_ADMIN_USER: $CADDY_ADMIN_USER
-      CADDY_ADMIN_PASSWORD: $CADDY_ADMIN_PASSWORD
-      TELEGRAM_WEBHOOK_SECRET: $TELEGRAM_WEBHOOK_SECRET
+      CADDY_SUBDOMAIN: ${CADDY_SUBDOMAIN:-}
+      CADDY_SUBDOMAIN2: ${CADDY_SUBDOMAIN2:-}
+      CADDY_SUBDOMAIN3: ${CADDY_SUBDOMAIN3:-}
+      CADDY_ADMIN_USER: ${CADDY_ADMIN_USER:-}
+      CADDY_ADMIN_PASSWORD: ${CADDY_ADMIN_PASSWORD:-}
+      TELEGRAM_WEBHOOK_SECRET: ${TELEGRAM_WEBHOOK_SECRET:-}
     networks:
       backend_net:
       homelan:
@@ -37,7 +37,7 @@ services:
       - ./site:/target
       - ./scripts:/scripts:ro
     environment:
-      GITHUB_TOKEN: $GITHUB_TOKEN
+      GITHUB_TOKEN: ${GITHUB_TOKEN:-}
       GITHUB_ASSET_REF: ${GITHUB_ASSET_REF:-main}
     command: ["sh", "/scripts/fetch-workflow-assets.sh"]
     restart: "no"


### PR DESCRIPTION
## Summary
- Keep the GitHub webhook `/webhook/github-pr-dashboard` reachable directly
- Protect the browser-facing n8n UI on `workflow.*` with Authelia forward auth
- Document the split behavior in the README

## Notes
- mTLS is still enforced for the non-webhook workflow paths
- I could not run `caddy validate` locally because `caddy` is not installed in this environment