### PR TITLE
Protect Paperless with Authelia forward auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ The reverse proxy exposes Authelia at `auth.{$CADDY_SUBDOMAIN}` and forwards tra
 
 Related stack: https://github.com/sidey79/authelia-docker
 
+## Paperless Authentication
+
+`dms.{$CADDY_SUBDOMAIN}` is protected by Authelia `forward_auth` and no longer uses
+client-certificate access control. Caddy forwards the authenticated Authelia identity
+headers upstream so Paperless can authenticate users via `HTTP_REMOTE_USER`.
+
 ## FHEM Authentication
 
 `fhem.{$CADDY_SUBDOMAIN}` accepts either a valid client certificate or a successful

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -155,9 +155,14 @@ fhem.{$CADDY_SUBDOMAIN} {
 }
 
 dms.{$CADDY_SUBDOMAIN} {
-	import mTLS_required
 	encode gzip
-	reverse_proxy http://paperless-ngx-webserver-1.network_backend_net:8000
+	import authelia_forward_auth
+	reverse_proxy http://paperless-ngx-webserver-1.network_backend_net:8000 {
+		header_up Remote-User {header.Remote-User}
+		header_up Remote-Groups {header.Remote-Groups}
+		header_up Remote-Email {header.Remote-Email}
+		header_up Remote-Name {header.Remote-Name}
+	}
 	import logging_info
 }
 

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -157,12 +157,7 @@ fhem.{$CADDY_SUBDOMAIN} {
 dms.{$CADDY_SUBDOMAIN} {
 	encode gzip
 	import authelia_forward_auth
-	reverse_proxy http://paperless-ngx-webserver-1.network_backend_net:8000 {
-		header_up Remote-User {header.Remote-User}
-		header_up Remote-Groups {header.Remote-Groups}
-		header_up Remote-Email {header.Remote-Email}
-		header_up Remote-Name {header.Remote-Name}
-	}
+	reverse_proxy http://paperless-ngx-webserver-1.network_backend_net:8000
 	import logging_info
 }
 


### PR DESCRIPTION
## Summary
- switch the `dms` vhost from mTLS-only access to Authelia `forward_auth`
- forward Authelia identity headers upstream so Paperless can use `HTTP_REMOTE_USER`
- document the Paperless authentication path in the repo README

## Validation
- `docker compose -f docker-compose.yml config`
- `caddy validate --config caddy/Caddyfile` currently fails on an unrelated pre-existing matcher in the `workflow` block (`header X-Telegram-Bot-Api-Secret-Token {$TELEGRAM_WEBHOOK_SECRET}`)

## Notes
- the `dms` upstream remains `paperless-ngx-webserver-1.network_backend_net:8000`
- Authelia remains the enforced login path for Paperless