### PR TITLE
[codex] Add Authelia landing page and identity proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,24 @@ When a valid client certificate is present, Caddy also forwards these headers to
 - `X-Client-Cert-Fingerprint`
 
 The route uses `mTLS_optional`. The workflow host does not expose the n8n editor or any generic
-backend path. It only serves the local workflow asset store from `/assets/*`, protects the browser
-UI for `/webhook/github-pr-dashboard` with Authelia, and forwards the `POST` webhook request to
-n8n. If a client certificate is provided, selected certificate metadata is forwarded to Authelia
-via headers:
+backend path. It only serves the local workflow asset store from `/assets/*`, exposes `GET/HEAD
+/api/me` behind Authelia without requiring a client certificate, protects the browser UI for
+`/webhook/github-pr-dashboard` with Authelia, and forwards the `POST` webhook request to n8n. If a
+client certificate is provided, selected certificate metadata is forwarded to Authelia via headers:
 
 - `X-Client-Cert-Serial`
 - `X-Client-Cert-Subject`
 - `X-Client-Cert-Fingerprint`
+
+## Landing Page
+
+`landing.{$CADDY_SUBDOMAIN}` is protected by Authelia and serves static files from
+`site/landingpage`.
+
+The same host exposes `GET /api/me` and rewrites that request to the internal n8n webhook path
+`/webhook/landing/api/me` before proxying it upstream. This keeps the browser UI and the identity
+API on the same origin without requiring a client certificate. The workflow host also accepts
+`GET/HEAD /api/me` as a narrow alias to the same internal n8n webhook.
 
 ## Environment
 

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -247,10 +247,36 @@ ui.{$CADDY_SUBDOMAIN} {
 	}
 }
 
+landing.{$CADDY_SUBDOMAIN} {
+	encode gzip
+	@landingApiMe {
+		method GET HEAD
+		path /api/me
+	}
+	route {
+		handle @landingApiMe {
+			import authelia_forward_auth
+			rewrite * /webhook/landing/api/me
+			import n8n_upstream
+		}
+		handle {
+			import authelia_forward_auth
+			root * /srv/landingpage
+			try_files {path} /index.html
+			file_server
+		}
+	}
+	import logging_info
+}
+
 workflow.{$CADDY_SUBDOMAIN} {
 	import mTLS_optional
 	@workflowAssets {
 		path /assets/*
+	}
+	@apiMe {
+		method GET HEAD
+		path /api/me
 	}
 	# Allow Telegram to call only the Scanservjs token reissue webhook without mTLS.
 	@telegramReissueWebhook {
@@ -270,6 +296,11 @@ workflow.{$CADDY_SUBDOMAIN} {
 		handle @workflowAssets {
 			root * /srv/workflow
 			file_server
+		}
+		handle @apiMe {
+			import authelia_forward_auth
+			rewrite * /webhook/landing/api/me
+			import n8n_upstream
 		}
 		handle @telegramReissueWebhook {
 			import n8n_upstream

--- a/site/landingpage/app.js
+++ b/site/landingpage/app.js
@@ -1,0 +1,75 @@
+function buildServiceUrl(subdomain, path = "") {
+  const host = window.location.hostname;
+  const baseHost = host.replace(/^landing\./, "");
+  const normalizedPath = path || "";
+
+  if (!subdomain || !baseHost || baseHost === host) {
+    return normalizedPath || "/";
+  }
+
+  return `https://${subdomain}.${baseHost}${normalizedPath}`;
+}
+
+function hydrateLinks() {
+  const links = document.querySelectorAll("[data-subdomain]");
+  links.forEach((link) => {
+    const subdomain = link.getAttribute("data-subdomain");
+    const path = link.getAttribute("data-path") || "";
+    link.href = buildServiceUrl(subdomain, path);
+  });
+}
+
+function renderIdentity(profile) {
+  const identityName = document.getElementById("identity-name");
+  const identityMeta = document.getElementById("identity-meta");
+  const rolePill = document.getElementById("role-pill");
+  const adminSection = document.getElementById("admin-section");
+
+  const displayName = profile.name || profile.user || "Unbekannt";
+  const groups = Array.isArray(profile.groups) ? profile.groups : [];
+  const role = profile.role || "family";
+
+  identityName.textContent = displayName;
+  identityMeta.textContent = [profile.email || "ohne Mailadresse", groups.join(", ") || "ohne Gruppen"]
+    .filter(Boolean)
+    .join(" • ");
+  rolePill.textContent = role;
+
+  if (role === "admin" || groups.includes("admin") || groups.includes("admins")) {
+    adminSection.hidden = false;
+  }
+}
+
+function renderFallback(error) {
+  const identityName = document.getElementById("identity-name");
+  const identityMeta = document.getElementById("identity-meta");
+  const rolePill = document.getElementById("role-pill");
+
+  identityName.textContent = "Profil nicht verfuegbar";
+  identityMeta.textContent = `Die Personalisierung konnte nicht geladen werden: ${error}`;
+  rolePill.textContent = "family";
+}
+
+async function loadProfile() {
+  try {
+    const response = await fetch("/api/me", {
+      credentials: "same-origin",
+      headers: {
+        Accept: "application/json",
+      },
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+
+    const profile = await response.json();
+    renderIdentity(profile);
+  } catch (error) {
+    renderFallback(error instanceof Error ? error.message : String(error));
+  }
+}
+
+hydrateLinks();
+loadProfile();

--- a/site/landingpage/app.js
+++ b/site/landingpage/app.js
@@ -10,6 +10,42 @@ function buildServiceUrl(subdomain, path = "") {
   return `https://${subdomain}.${baseHost}${normalizedPath}`;
 }
 
+function getPreferredTheme() {
+  const storedTheme = window.localStorage.getItem("landing-theme");
+  if (storedTheme === "light" || storedTheme === "dark") {
+    return storedTheme;
+  }
+
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function applyTheme(theme) {
+  const root = document.documentElement;
+  const themeToggle = document.getElementById("theme-toggle");
+  root.dataset.theme = theme;
+
+  if (themeToggle) {
+    const darkActive = theme === "dark";
+    themeToggle.setAttribute("aria-pressed", darkActive ? "true" : "false");
+    themeToggle.querySelector(".theme-toggle-label").textContent = darkActive ? "Hellmodus" : "Darkmode";
+  }
+}
+
+function initializeThemeToggle() {
+  const themeToggle = document.getElementById("theme-toggle");
+  applyTheme(getPreferredTheme());
+
+  if (!themeToggle) {
+    return;
+  }
+
+  themeToggle.addEventListener("click", () => {
+    const nextTheme = document.documentElement.dataset.theme === "dark" ? "light" : "dark";
+    window.localStorage.setItem("landing-theme", nextTheme);
+    applyTheme(nextTheme);
+  });
+}
+
 function hydrateLinks() {
   const links = document.querySelectorAll("[data-subdomain]");
   links.forEach((link) => {
@@ -71,5 +107,6 @@ async function loadProfile() {
   }
 }
 
+initializeThemeToggle();
 hydrateLinks();
 loadProfile();

--- a/site/landingpage/index.html
+++ b/site/landingpage/index.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Serviceportal</title>
+    <link rel="stylesheet" href="/styles.css">
+    <script src="/app.js" defer></script>
+  </head>
+  <body>
+    <main class="shell">
+      <section class="hero">
+        <p class="eyebrow">Authelia Landing Page</p>
+        <div class="hero-grid">
+          <div>
+            <h1>Dein Einstieg in die internen Dienste</h1>
+            <p class="lead">
+              Die Startseite zeigt Familien-Links standardmaessig und erweitert sich fuer Admins um
+              Infrastruktur, Automationen und technische Oberflaechen.
+            </p>
+          </div>
+          <aside class="identity-card" aria-live="polite">
+            <p class="identity-label">Sitzung</p>
+            <p class="identity-name" id="identity-name">Wird geladen</p>
+            <p class="identity-meta" id="identity-meta">Pruefe Authelia-Kontext</p>
+            <span class="role-pill" id="role-pill">unbekannt</span>
+          </aside>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="section-head">
+          <h2>Alltag</h2>
+          <p>Direkte Links fuer Dokumente, Anmeldung und die Oberflaechen, die im Alltag relevant sind.</p>
+        </div>
+        <div class="card-grid">
+          <a class="service-card" data-subdomain="dms" href="#">
+            <span class="service-kicker">Dokumente</span>
+            <strong>Paperless</strong>
+            <span>Briefe, Rechnungen und Sucharchiv.</span>
+          </a>
+          <a class="service-card" data-subdomain="auth" href="#">
+            <span class="service-kicker">Anmeldung</span>
+            <strong>Authelia</strong>
+            <span>Login, Session und Zugriffsportal.</span>
+          </a>
+        </div>
+      </section>
+
+      <section class="section admin-only" id="admin-section" hidden>
+        <div class="section-head">
+          <h2>Admin</h2>
+          <p>Nur fuer Accounts mit Admin-Gruppe. Die Zielhosts werden aus der aktuellen Landing-Domain abgeleitet.</p>
+        </div>
+        <div class="card-grid">
+          <a class="service-card" data-subdomain="fhem" href="#">
+            <span class="service-kicker">Automation</span>
+            <strong>FHEM</strong>
+            <span>Zentrale Hausautomation und Geraetelogik.</span>
+          </a>
+          <a class="service-card" data-subdomain="ui" href="#">
+            <span class="service-kicker">Smart Home</span>
+            <strong>FTUI</strong>
+            <span>Bedienoberflaeche fuer Hausstatus und Schnellaktionen, zusaetzlich mTLS-geschuetzt.</span>
+          </a>
+          <a class="service-card" data-subdomain="bitwarden" href="#">
+            <span class="service-kicker">Sicherheit</span>
+            <strong>Bitwarden</strong>
+            <span>Passwortverwaltung und Admin-Oberflaeche.</span>
+          </a>
+          <a class="service-card" data-subdomain="workflow" data-path="/webhook/github-pr-dashboard" href="#">
+            <span class="service-kicker">Automationen</span>
+            <strong>GitHub PR Dashboard</strong>
+            <span>Statusansicht fuer Pull Requests ueber den Workflow-Host.</span>
+          </a>
+        </div>
+      </section>
+
+      <section class="section note">
+        <div class="section-head">
+          <h2>Hinweis</h2>
+        </div>
+        <p>
+          Diese Seite blendet nur Links ein oder aus. Die Zielsysteme muessen weiterhin selbst ueber
+          Authelia, mTLS oder eigene Anmeldung geschuetzt bleiben.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/site/landingpage/index.html
+++ b/site/landingpage/index.html
@@ -10,7 +10,12 @@
   <body>
     <main class="shell">
       <section class="hero">
-        <p class="eyebrow">Authelia Landing Page</p>
+        <div class="hero-topline">
+          <p class="eyebrow">Authelia Landing Page</p>
+          <button class="theme-toggle" id="theme-toggle" type="button" aria-pressed="false">
+            <span class="theme-toggle-label">Darkmode</span>
+          </button>
+        </div>
         <div class="hero-grid">
           <div>
             <h1>Dein Einstieg in die internen Dienste</h1>
@@ -34,15 +39,30 @@
           <p>Direkte Links fuer Dokumente, Anmeldung und die Oberflaechen, die im Alltag relevant sind.</p>
         </div>
         <div class="card-grid">
-          <a class="service-card" data-subdomain="dms" href="#">
+          <a class="service-card service-card-amber" data-subdomain="dms" href="#">
+            <span class="service-icon" aria-hidden="true">
+              <svg viewBox="0 0 64 64" role="img">
+                <rect x="14" y="10" width="36" height="44" rx="8"></rect>
+                <path d="M22 24h20M22 32h20M22 40h12"></path>
+                <path d="M42 10v10h8"></path>
+              </svg>
+            </span>
             <span class="service-kicker">Dokumente</span>
-            <strong>Paperless</strong>
-            <span>Briefe, Rechnungen und Sucharchiv.</span>
+            <strong>Briefe und Unterlagen</strong>
+            <span>Rechnungen, Briefe und wichtige Dokumente schnell wiederfinden.</span>
           </a>
-          <a class="service-card" data-subdomain="auth" href="#">
+          <a class="service-card service-card-rose" data-subdomain="auth" href="#">
+            <span class="service-icon" aria-hidden="true">
+              <svg viewBox="0 0 64 64" role="img">
+                <rect x="12" y="28" width="40" height="24" rx="8"></rect>
+                <path d="M22 28v-6a10 10 0 0 1 20 0v6"></path>
+                <circle cx="32" cy="40" r="3"></circle>
+                <path d="M32 43v5"></path>
+              </svg>
+            </span>
             <span class="service-kicker">Anmeldung</span>
-            <strong>Authelia</strong>
-            <span>Login, Session und Zugriffsportal.</span>
+            <strong>Zugang und Sicherheit</strong>
+            <span>Anmeldung verwalten und geschuetzte Bereiche sicher erreichen.</span>
           </a>
         </div>
       </section>
@@ -53,25 +73,55 @@
           <p>Nur fuer Accounts mit Admin-Gruppe. Die Zielhosts werden aus der aktuellen Landing-Domain abgeleitet.</p>
         </div>
         <div class="card-grid">
-          <a class="service-card" data-subdomain="fhem" href="#">
+          <a class="service-card service-card-mint" data-subdomain="fhem" href="#">
+            <span class="service-icon" aria-hidden="true">
+              <svg viewBox="0 0 64 64" role="img">
+                <circle cx="20" cy="32" r="6"></circle>
+                <circle cx="44" cy="20" r="6"></circle>
+                <circle cx="44" cy="44" r="6"></circle>
+                <path d="M26 30l12-8M26 34l12 8"></path>
+              </svg>
+            </span>
             <span class="service-kicker">Automation</span>
-            <strong>FHEM</strong>
-            <span>Zentrale Hausautomation und Geraetelogik.</span>
+            <strong>Haussteuerung</strong>
+            <span>Automationen, Schalter und Geraete zentral verwalten.</span>
           </a>
-          <a class="service-card" data-subdomain="ui" href="#">
+          <a class="service-card service-card-sky" data-subdomain="ui" href="#">
+            <span class="service-icon" aria-hidden="true">
+              <svg viewBox="0 0 64 64" role="img">
+                <path d="M16 30a16 16 0 0 1 32 0v18H16z"></path>
+                <path d="M24 24a8 8 0 0 1 16 0"></path>
+                <path d="M24 48v-8M32 48v-12M40 48v-6"></path>
+              </svg>
+            </span>
             <span class="service-kicker">Smart Home</span>
-            <strong>FTUI</strong>
-            <span>Bedienoberflaeche fuer Hausstatus und Schnellaktionen, zusaetzlich mTLS-geschuetzt.</span>
+            <strong>Wohnung im Blick</strong>
+            <span>Status sehen und Schnellaktionen nutzen, mit zusaetzlichem Zertifikatsschutz.</span>
           </a>
-          <a class="service-card" data-subdomain="bitwarden" href="#">
+          <a class="service-card service-card-violet" data-subdomain="bitwarden" href="#">
+            <span class="service-icon" aria-hidden="true">
+              <svg viewBox="0 0 64 64" role="img">
+                <path d="M32 10l16 6v12c0 12-7 20-16 26-9-6-16-14-16-26V16z"></path>
+                <rect x="25" y="26" width="14" height="12" rx="3"></rect>
+                <path d="M28 26v-3a4 4 0 0 1 8 0v3"></path>
+              </svg>
+            </span>
             <span class="service-kicker">Sicherheit</span>
-            <strong>Bitwarden</strong>
-            <span>Passwortverwaltung und Admin-Oberflaeche.</span>
+            <strong>Passwoerter und Zugaenge</strong>
+            <span>Wichtige Logins sicher ablegen und verwalten.</span>
           </a>
-          <a class="service-card" data-subdomain="workflow" data-path="/webhook/github-pr-dashboard" href="#">
+          <a class="service-card service-card-coral" data-subdomain="workflow" data-path="/webhook/github-pr-dashboard" href="#">
+            <span class="service-icon" aria-hidden="true">
+              <svg viewBox="0 0 64 64" role="img">
+                <rect x="12" y="14" width="40" height="36" rx="8"></rect>
+                <path d="M22 38l6-8 6 4 8-12"></path>
+                <path d="M22 24h20"></path>
+                <circle cx="42" cy="22" r="2"></circle>
+              </svg>
+            </span>
             <span class="service-kicker">Automationen</span>
-            <strong>GitHub PR Dashboard</strong>
-            <span>Statusansicht fuer Pull Requests ueber den Workflow-Host.</span>
+            <strong>Projektstatus</strong>
+            <span>Technische Arbeitsstaende und laufende Aenderungen schnell ueberblicken.</span>
           </a>
         </div>
       </section>

--- a/site/landingpage/styles.css
+++ b/site/landingpage/styles.css
@@ -1,0 +1,205 @@
+:root {
+  color-scheme: light;
+  --bg-top: #f5efe3;
+  --bg-bottom: #d8e2ec;
+  --panel: rgba(255, 255, 255, 0.78);
+  --panel-border: rgba(32, 49, 63, 0.12);
+  --text: #1d2d35;
+  --muted: #5d6b72;
+  --accent: #0e7c66;
+  --accent-soft: #d7efe8;
+  --shadow: 0 24px 60px rgba(24, 38, 47, 0.14);
+  --radius-lg: 28px;
+  --radius-md: 18px;
+  --font-ui: "IBM Plex Sans", "Avenir Next", "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: var(--font-ui);
+  color: var(--text);
+  background:
+    radial-gradient(circle at top left, rgba(255, 255, 255, 0.9), transparent 38%),
+    linear-gradient(155deg, var(--bg-top), var(--bg-bottom));
+}
+
+.shell {
+  width: min(1120px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 2rem 0 4rem;
+}
+
+.hero,
+.section {
+  background: var(--panel);
+  backdrop-filter: blur(14px);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow);
+}
+
+.hero {
+  padding: 2rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.76rem;
+  color: var(--muted);
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.8fr) minmax(280px, 0.9fr);
+  gap: 1.5rem;
+  align-items: start;
+}
+
+h1,
+h2,
+p {
+  margin: 0;
+}
+
+h1 {
+  max-width: 12ch;
+  font-size: clamp(2.4rem, 5vw, 4.4rem);
+  line-height: 0.95;
+}
+
+.lead {
+  max-width: 62ch;
+  margin-top: 1rem;
+  font-size: 1.05rem;
+  line-height: 1.65;
+  color: var(--muted);
+}
+
+.identity-card {
+  padding: 1.25rem;
+  border-radius: var(--radius-md);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(236, 246, 242, 0.96));
+  border: 1px solid rgba(14, 124, 102, 0.18);
+}
+
+.identity-label,
+.service-kicker {
+  display: block;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.identity-name {
+  margin-top: 0.4rem;
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.identity-meta {
+  margin-top: 0.45rem;
+  line-height: 1.5;
+  color: var(--muted);
+}
+
+.role-pill {
+  display: inline-flex;
+  margin-top: 1rem;
+  padding: 0.45rem 0.8rem;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.section {
+  margin-top: 1.4rem;
+  padding: 1.5rem;
+}
+
+.section-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: end;
+  margin-bottom: 1rem;
+}
+
+.section-head p {
+  max-width: 54ch;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.service-card {
+  display: grid;
+  gap: 0.45rem;
+  min-height: 160px;
+  padding: 1rem;
+  text-decoration: none;
+  color: inherit;
+  background: rgba(255, 255, 255, 0.84);
+  border: 1px solid rgba(29, 45, 53, 0.08);
+  border-radius: var(--radius-md);
+  transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
+}
+
+.service-card strong {
+  font-size: 1.25rem;
+}
+
+.service-card span:last-child {
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.service-card:hover,
+.service-card:focus-visible {
+  transform: translateY(-3px);
+  border-color: rgba(14, 124, 102, 0.28);
+  box-shadow: 0 16px 30px rgba(24, 38, 47, 0.12);
+}
+
+.note p {
+  line-height: 1.65;
+  color: var(--muted);
+}
+
+@media (max-width: 760px) {
+  .shell {
+    width: min(100% - 1rem, 1120px);
+    padding-top: 1rem;
+  }
+
+  .hero,
+  .section {
+    padding: 1.2rem;
+    border-radius: 22px;
+  }
+
+  .hero-grid,
+  .section-head {
+    grid-template-columns: 1fr;
+    display: grid;
+  }
+
+  h1 {
+    max-width: none;
+  }
+}

--- a/site/landingpage/styles.css
+++ b/site/landingpage/styles.css
@@ -1,17 +1,42 @@
 :root {
   color-scheme: light;
-  --bg-top: #f5efe3;
-  --bg-bottom: #d8e2ec;
-  --panel: rgba(255, 255, 255, 0.78);
-  --panel-border: rgba(32, 49, 63, 0.12);
-  --text: #1d2d35;
-  --muted: #5d6b72;
-  --accent: #0e7c66;
-  --accent-soft: #d7efe8;
-  --shadow: 0 24px 60px rgba(24, 38, 47, 0.14);
+  --bg-top: #fff2dd;
+  --bg-bottom: #dcecff;
+  --bg-glow-a: rgba(255, 159, 67, 0.32);
+  --bg-glow-b: rgba(106, 167, 255, 0.28);
+  --panel: rgba(255, 255, 255, 0.76);
+  --panel-border: rgba(43, 58, 74, 0.12);
+  --text: #20303b;
+  --muted: #60717b;
+  --accent: #176f5c;
+  --accent-soft: #dbf1ea;
+  --shadow: 0 24px 60px rgba(39, 57, 71, 0.14);
   --radius-lg: 28px;
   --radius-md: 18px;
   --font-ui: "IBM Plex Sans", "Avenir Next", "Segoe UI", sans-serif;
+  --button-bg: rgba(255, 255, 255, 0.72);
+  --button-border: rgba(43, 58, 74, 0.12);
+  --card-bg: rgba(255, 255, 255, 0.84);
+  --card-border: rgba(29, 45, 53, 0.08);
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --bg-top: #102033;
+  --bg-bottom: #1d1530;
+  --bg-glow-a: rgba(249, 148, 70, 0.18);
+  --bg-glow-b: rgba(93, 178, 255, 0.16);
+  --panel: rgba(15, 24, 35, 0.78);
+  --panel-border: rgba(192, 212, 233, 0.12);
+  --text: #edf5fb;
+  --muted: #a6b8c7;
+  --accent: #76dec0;
+  --accent-soft: rgba(118, 222, 192, 0.16);
+  --shadow: 0 24px 70px rgba(3, 8, 15, 0.46);
+  --button-bg: rgba(22, 34, 48, 0.84);
+  --button-border: rgba(192, 212, 233, 0.12);
+  --card-bg: rgba(18, 28, 40, 0.88);
+  --card-border: rgba(192, 212, 233, 0.12);
 }
 
 * {
@@ -24,7 +49,8 @@ body {
   font-family: var(--font-ui);
   color: var(--text);
   background:
-    radial-gradient(circle at top left, rgba(255, 255, 255, 0.9), transparent 38%),
+    radial-gradient(circle at top left, var(--bg-glow-a), transparent 32%),
+    radial-gradient(circle at 85% 10%, var(--bg-glow-b), transparent 28%),
     linear-gradient(155deg, var(--bg-top), var(--bg-bottom));
 }
 
@@ -47,12 +73,38 @@ body {
   padding: 2rem;
 }
 
+.hero-topline {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
 .eyebrow {
-  margin: 0 0 0.75rem;
+  margin: 0;
   text-transform: uppercase;
   letter-spacing: 0.18em;
   font-size: 0.76rem;
   color: var(--muted);
+}
+
+.theme-toggle {
+  border: 1px solid var(--button-border);
+  background: var(--button-bg);
+  color: var(--text);
+  padding: 0.65rem 0.95rem;
+  border-radius: 999px;
+  font: inherit;
+  font-size: 0.92rem;
+  cursor: pointer;
+  transition: transform 180ms ease, border-color 180ms ease, background 180ms ease;
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(23, 111, 92, 0.28);
 }
 
 .hero-grid {
@@ -86,8 +138,13 @@ h1 {
   padding: 1.25rem;
   border-radius: var(--radius-md);
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(236, 246, 242, 0.96));
+    linear-gradient(180deg, rgba(255, 255, 255, 0.82), rgba(228, 248, 241, 0.94));
   border: 1px solid rgba(14, 124, 102, 0.18);
+}
+
+:root[data-theme="dark"] .identity-card {
+  background:
+    linear-gradient(180deg, rgba(26, 38, 52, 0.92), rgba(15, 47, 46, 0.92));
 }
 
 .identity-label,
@@ -154,10 +211,32 @@ h1 {
   padding: 1rem;
   text-decoration: none;
   color: inherit;
-  background: rgba(255, 255, 255, 0.84);
-  border: 1px solid rgba(29, 45, 53, 0.08);
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: var(--radius-md);
   transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
+}
+
+.service-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3.4rem;
+  height: 3.4rem;
+  margin-bottom: 0.35rem;
+  border-radius: 16px;
+  background: linear-gradient(145deg, var(--icon-bg-strong, rgba(23, 111, 92, 0.16)), var(--icon-bg-soft, rgba(23, 111, 92, 0.05)));
+  color: var(--icon-color, var(--accent));
+}
+
+.service-icon svg {
+  width: 2rem;
+  height: 2rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2.2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .service-card strong {
@@ -172,8 +251,44 @@ h1 {
 .service-card:hover,
 .service-card:focus-visible {
   transform: translateY(-3px);
-  border-color: rgba(14, 124, 102, 0.28);
+  border-color: var(--icon-color, rgba(14, 124, 102, 0.28));
   box-shadow: 0 16px 30px rgba(24, 38, 47, 0.12);
+}
+
+.service-card-amber {
+  --icon-color: #ba6b12;
+  --icon-bg-strong: rgba(255, 183, 77, 0.24);
+  --icon-bg-soft: rgba(255, 183, 77, 0.08);
+}
+
+.service-card-rose {
+  --icon-color: #ba4b73;
+  --icon-bg-strong: rgba(255, 132, 178, 0.22);
+  --icon-bg-soft: rgba(255, 132, 178, 0.08);
+}
+
+.service-card-mint {
+  --icon-color: #157c69;
+  --icon-bg-strong: rgba(76, 214, 174, 0.2);
+  --icon-bg-soft: rgba(76, 214, 174, 0.08);
+}
+
+.service-card-sky {
+  --icon-color: #256fb8;
+  --icon-bg-strong: rgba(101, 177, 255, 0.22);
+  --icon-bg-soft: rgba(101, 177, 255, 0.08);
+}
+
+.service-card-violet {
+  --icon-color: #7251bf;
+  --icon-bg-strong: rgba(167, 125, 255, 0.22);
+  --icon-bg-soft: rgba(167, 125, 255, 0.08);
+}
+
+.service-card-coral {
+  --icon-color: #c55f46;
+  --icon-bg-strong: rgba(255, 143, 110, 0.22);
+  --icon-bg-soft: rgba(255, 143, 110, 0.08);
 }
 
 .note p {
@@ -193,6 +308,7 @@ h1 {
     border-radius: 22px;
   }
 
+  .hero-topline,
   .hero-grid,
   .section-head {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
- add a dedicated `landing.{CADDY_SUBDOMAIN}` site protected by Authelia
- expose `/api/me` on the landing host and as a narrow alias on `workflow.*`, both rewritten to the internal n8n webhook path
- add a static landing page that derives service URLs from the current host and shows fewer links for family users than for admins

## Why
The Authelia default redirect needs a human-friendly landing page, while the page itself needs a small same-origin identity endpoint to decide whether to show admin-only links.

## User impact
- authenticated users can land on a simple service hub after Authelia login
- admins see additional links for infrastructure and automation tools
- the identity endpoint is limited to `GET/HEAD` and does not expose generic n8n backend paths

## Validation
- reviewed the Caddy routing against existing `forward_auth` and `mTLS_optional` patterns
- ran `git diff --check`
- did not run `caddy validate` in a live runtime