### PR TITLE
Add local Vaultwarden admin host

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -180,13 +180,16 @@ auth.{$CADDY_SUBDOMAIN} {
 	redir @admin /
 }
 (bitwarden_security_headers) {
+	import bitwarden_frame_options DENY
+}
+(bitwarden_frame_options) {
 	header / {
 		# Enable HTTP Strict Transport Security (HSTS)
 		Strict-Transport-Security "max-age=31536000;"
 		# Disable cross-site filter (XSS)
 		X-XSS-Protection "0"
 		# Disallow the site to be rendered within a frame (clickjacking protection)
-		X-Frame-Options "DENY"
+		X-Frame-Options "{args[0]}"
 		# Prevent search engines from indexing (optional)
 		X-Robots-Tag "noindex, nofollow"
 		# Disallow sniffing of X-Content-Type-Options
@@ -226,15 +229,9 @@ bitwarden.{$CADDY_SUBDOMAIN3} {
 		issuer internal {
 			ca blausee_ca
 		}
-		client_auth {
-			mode require_and_verify
-			trust_pool file {
-				pem_file /etc/ssl/ca/certs/blausee_ca.crt
-			}
-		}
 	}
 	encode gzip
-	import bitwarden_security_headers
+	import bitwarden_frame_options SAMEORIGIN
 	import bitwarden_upstream
 	import logging_info
 }

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -176,22 +176,10 @@ auth.{$CADDY_SUBDOMAIN} {
 (admin_redir) {
 	@admin {
 		path /admin*
-		not remote_ip private_ranges
 	}
 	redir @admin /
 }
-
-bitwarden.{$CADDY_SUBDOMAIN} {
-	encode gzip
-	import admin_redir
-	route {
-		@tasks path /api/tasks
-		handle @tasks {
-			header Content-Type application/json
-			respond `{"data":[],"object":"list"}` 200
-		}
-	}
-	# If you want to use FIDO2 WebAuthn, set X-Frame-Options to "SAMEORIGIN" or the Browser will block those requests
+(bitwarden_security_headers) {
 	header / {
 		# Enable HTTP Strict Transport Security (HSTS)
 		Strict-Transport-Security "max-age=31536000;"
@@ -210,9 +198,44 @@ bitwarden.{$CADDY_SUBDOMAIN} {
 		# Remove Last-Modified because etag is the same and is as effective
 		-Last-Modified
 	}
+}
+(bitwarden_upstream) {
 	reverse_proxy http://bitwarden.network_backend_net:8889 {
 		header_up X-Real-IP {remote_host}
 	}
+}
+
+bitwarden.{$CADDY_SUBDOMAIN} {
+	encode gzip
+	import admin_redir
+	route {
+		@tasks path /api/tasks
+		handle @tasks {
+			header Content-Type application/json
+			respond `{"data":[],"object":"list"}` 200
+		}
+	}
+	# If you want to use FIDO2 WebAuthn, set X-Frame-Options to "SAMEORIGIN" or the Browser will block those requests
+	import bitwarden_security_headers
+	import bitwarden_upstream
+	import logging_info
+}
+
+bitwarden.{$CADDY_SUBDOMAIN3} {
+	tls {
+		issuer internal {
+			ca blausee_ca
+		}
+		client_auth {
+			mode require_and_verify
+			trust_pool file {
+				pem_file /etc/ssl/ca/certs/blausee_ca.crt
+			}
+		}
+	}
+	encode gzip
+	import bitwarden_security_headers
+	import bitwarden_upstream
 	import logging_info
 }
 


### PR DESCRIPTION
## Summary

- block `/admin` on the public Vaultwarden host without relying on detected client IP ranges
- add reusable Vaultwarden security header and upstream snippets
- expose `bitwarden.${CADDY_SUBDOMAIN3}` as a local mTLS-protected host for Vaultwarden admin access

## Validation

- validated the Caddyfile with `docker exec reverseproxy-caddy-1 caddy validate --config /etc/caddy/Caddyfile`
- reloaded the running Caddy container with the validated configuration

## Notes

The local host requires DNS/mDNS, for example an Avahi alias such as `avahi-alias-Caddy@bitwarden.local.service` when `CADDY_SUBDOMAIN3=local`.