### PR TITLE
[codex] disable FHEM upstream keepalive

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+- Do not modify the live reverse proxy configuration on this host. Changes must be made in the repository and delivered through a pull request.

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -84,7 +84,7 @@
 (fhem_transport) {
 	transport http {
 		versions 1.1
-		keepalive 30s
+		keepalive off
 		tls_server_name zeus.fritz.box
 		tls_trust_pool file {
 			pem_file /etc/ssl/ca/certs/blausee_ca.crt

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -83,6 +83,8 @@
 }
 (fhem_transport) {
 	transport http {
+		versions 1.1
+		keepalive 30s
 		tls_server_name zeus.fritz.box
 		tls_trust_pool file {
 			pem_file /etc/ssl/ca/certs/blausee_ca.crt


### PR DESCRIPTION
## Summary

- set the Caddy FHEM upstream transport to HTTP/1.1 and disable upstream keepalive reuse
- add `AGENTS.MD` documenting that live reverse proxy configuration must not be changed locally and changes must go through PRs

## Why

FHEM can support HTTP keepalive, but the live logs still show clustered `502` responses immediately after Caddy startup with upstream errors such as `http: server closed idle connection` and `EOF`. Those failures happened within tens of seconds of restart, so simply keeping Caddy's upstream idle timeout below FHEM's 60 second idle close was not sufficient.

Disabling keepalive only for the FHEM upstream avoids reusing backend connections entirely while leaving the rest of the reverse proxy unchanged.

## Validation

- confirmed the live container had picked up the previous `keepalive 30s` configuration on disk
- observed current FHEM 502s still using `http: server closed idle connection` / `EOF`
- validated the new `transport http` settings with a minimal `caddy:2.11.2 caddy adapt` snippet
- did not modify or reload the live reverse proxy configuration from Codex