### PR TITLE
[codex] expose n8n OAuth2 credential endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ client certificate is provided, selected certificate metadata is forwarded to Au
 - `X-Client-Cert-Subject`
 - `X-Client-Cert-Fingerprint`
 
+The workflow host also forwards `GET/HEAD/OPTIONS /rest/oauth2-credential*` directly to n8n. This
+keeps n8n OAuth2 callback URLs such as `https://workflow.sidey.blausee.eu/rest/oauth2-credential`
+reachable by external OAuth providers without exposing the generic n8n editor or REST API.
+
 ## Landing Page
 
 `landing.{$CADDY_SUBDOMAIN}` is protected by Authelia and serves static files from

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -300,6 +300,10 @@ workflow.{$CADDY_SUBDOMAIN} {
 		method GET HEAD
 		path /api/me
 	}
+	@oauth2Credential {
+		method GET HEAD OPTIONS
+		path /rest/oauth2-credential*
+	}
 	# Allow Telegram to call only the Scanservjs token reissue webhook without mTLS.
 	@telegramReissueWebhook {
 		method POST
@@ -327,6 +331,9 @@ workflow.{$CADDY_SUBDOMAIN} {
 		handle @apiMe {
 			import authelia_forward_auth
 			rewrite * /webhook/landing/api/me
+			import n8n_upstream
+		}
+		handle @oauth2Credential {
 			import n8n_upstream
 		}
 		handle @telegramReissueWebhook {


### PR DESCRIPTION
## Summary

- allow `GET`, `HEAD`, and `OPTIONS` requests for `/rest/oauth2-credential*` on `workflow.{$CADDY_SUBDOMAIN}`
- forward that narrow route directly to the n8n upstream without Authelia or mTLS
- document why the route must be externally reachable for OAuth providers

## Why

External OAuth providers such as Google must be able to reach n8n's OAuth2 credential callback URL, for example `https://workflow.sidey.blausee.eu/rest/oauth2-credential`, during credential authorization flows.

## Validation

- `docker compose config`
- `caddy validate --config /work/caddy/Caddyfile`
- `git diff --check`