### PR TITLE
Allow mTLS workflow fallback to n8n

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,12 @@ When a valid client certificate is present, Caddy also forwards these headers to
 - `X-Client-Cert-Subject`
 - `X-Client-Cert-Fingerprint`
 
-The route uses `mTLS_optional`. The workflow host does not expose the n8n editor or any generic
-backend path. It only serves the local workflow asset store from `/assets/*`, exposes `GET/HEAD
-/api/me` behind Authelia without requiring a client certificate, protects the browser UI for
-`/webhook/github-pr-dashboard` with Authelia, and forwards the `POST` webhook request to n8n. If a
-client certificate is provided, selected certificate metadata is forwarded to Authelia via headers:
+The route uses `mTLS_optional`. Without a client certificate, the workflow host only serves the
+local workflow asset store from `/assets/*`, exposes `GET/HEAD /api/me` behind Authelia without
+requiring a client certificate, protects the browser UI for `/webhook/github-pr-dashboard` with
+Authelia, and forwards the `POST` webhook request to n8n. With a client certificate, all remaining
+`workflow.*` paths are forwarded to n8n after the explicit path exceptions have been evaluated. If a
+client certificate is provided, selected certificate metadata is forwarded upstream via headers:
 
 - `X-Client-Cert-Serial`
 - `X-Client-Cert-Subject`
@@ -43,7 +44,8 @@ client certificate is provided, selected certificate metadata is forwarded to Au
 
 The workflow host also forwards `GET/HEAD/OPTIONS /rest/oauth2-credential*` directly to n8n. This
 keeps n8n OAuth2 callback URLs such as `https://workflow.sidey.blausee.eu/rest/oauth2-credential`
-reachable by external OAuth providers without exposing the generic n8n editor or REST API.
+reachable by external OAuth providers without exposing the generic n8n editor or REST API to clients
+without a certificate.
 
 ## Landing Page
 
@@ -62,7 +64,7 @@ Set `TELEGRAM_WEBHOOK_SECRET` to the same value used by the Scanservjs Telegram 
 - `POST /webhook/scanservjs/telegram/reissue`
 - `POST /webhook-test/scanservjs/telegram/reissue`
 
-All other `workflow.*` paths remain protected by the existing mTLS policy.
+All other `workflow.*` paths require a client certificate and are then forwarded to n8n.
 
 The workflow host also exposes dedicated aliases for the Alexa/Gemini workflow:
 

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -295,7 +295,6 @@ workflow.{$CADDY_SUBDOMAIN} {
 	import mTLS_optional
 	@workflowAssets {
 		path /assets/*
-		expression {tls_client_fingerprint} == "" && {tls_client_serial} == "" && {tls_client_subject} == ""
 	}
 	@apiMe {
 		method GET HEAD

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -295,6 +295,7 @@ workflow.{$CADDY_SUBDOMAIN} {
 	import mTLS_optional
 	@workflowAssets {
 		path /assets/*
+		expression {tls_client_fingerprint} == "" && {tls_client_serial} == "" && {tls_client_subject} == ""
 	}
 	@apiMe {
 		method GET HEAD
@@ -317,11 +318,14 @@ workflow.{$CADDY_SUBDOMAIN} {
 	}
 	@webhooksMtls {
 		path /webhook/* /webhook-test/*
-		expression {tls_client_subject} != ""
+		expression {tls_client_fingerprint} != "" || {tls_client_serial} != "" || {tls_client_subject} != ""
 	}
 	@webhooksAuthelia {
 		path /webhook/* /webhook-test/*
-		expression {tls_client_subject} == ""
+		expression {tls_client_fingerprint} == "" && {tls_client_serial} == "" && {tls_client_subject} == ""
+	}
+	@workflowMtls {
+		expression {tls_client_fingerprint} != "" || {tls_client_serial} != "" || {tls_client_subject} != ""
 	}
 	route {
 		handle @workflowAssets {
@@ -347,6 +351,9 @@ workflow.{$CADDY_SUBDOMAIN} {
 		}
 		handle @webhooksAuthelia {
 			import authelia_forward_auth
+			import n8n_upstream
+		}
+		handle @workflowMtls {
 			import n8n_upstream
 		}
 	}


### PR DESCRIPTION
## Summary

- add a catch-all `workflow.*` route for requests with a verified client certificate
- keep existing explicit workflow path handling ahead of the mTLS fallback
- update the README to document that certificate-authenticated workflow paths proxy to n8n

## Validation

- `docker compose config`
- `docker run ... caddy validate --config /etc/caddy/Caddyfile`