### PR TITLE
[codex] add duplicati backup status to landingpage

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,3 +46,13 @@ jobs:
             -v "$RUNNER_TEMP/caddy-ca/private:/etc/ssl/ca/private:ro" \
             -w /work \
             "$CADDY_IMAGE" sh -lc 'caddy validate --config /work/caddy/Caddyfile'
+
+  endpoint-authz-policy:
+    name: runner / endpoint-authz-policy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+      - name: Verify auth-protected endpoint policy
+        run: |
+          bash scripts/test-auth-protected-endpoints.sh caddy/Caddyfile

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,3 +56,13 @@ jobs:
       - name: Verify auth-protected endpoint policy
         run: |
           bash scripts/test-auth-protected-endpoints.sh caddy/Caddyfile
+
+  endpoint-authz-e2e:
+    name: runner / endpoint-authz-e2e
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+      - name: Run E2E auth endpoint checks
+        run: |
+          bash scripts/test-auth-endpoints-e2e.sh

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -313,14 +313,6 @@ workflow.{$CADDY_SUBDOMAIN} {
 		method GET HEAD OPTIONS
 		path /rest/oauth2-credential*
 	}
-	@duplicatiWebhooksNoMtls {
-		path /webhook/duplicati/* /webhook-test/duplicati/*
-		expression {tls_client_fingerprint} == "" && {tls_client_serial} == "" && {tls_client_subject} == ""
-	}
-	@duplicatiWebhooksMtls {
-		path /webhook/duplicati/* /webhook-test/duplicati/*
-		expression {tls_client_fingerprint} != "" || {tls_client_serial} != "" || {tls_client_subject} != ""
-	}
 	# Allow Telegram to call only the Scanservjs token reissue webhook without mTLS.
 	@telegramReissueWebhook {
 		method POST
@@ -354,12 +346,6 @@ workflow.{$CADDY_SUBDOMAIN} {
 			import n8n_upstream
 		}
 		handle @oauth2Credential {
-			import n8n_upstream
-		}
-		handle @duplicatiWebhooksNoMtls {
-			respond "mTLS required for duplicati webhooks" 403
-		}
-		handle @duplicatiWebhooksMtls {
 			import n8n_upstream
 		}
 		handle @telegramReissueWebhook {

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -285,8 +285,9 @@ landing.{$CADDY_SUBDOMAIN} {
 			rewrite * /webhook/landing/api/me
 			import n8n_upstream
 		}
-		handle_path @landingDuplicati {
+		handle @landingDuplicati {
 			import authelia_forward_auth
+			uri strip_prefix /duplicati
 			import n8n_upstream
 		}
 		handle {

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -312,6 +312,14 @@ workflow.{$CADDY_SUBDOMAIN} {
 		method GET HEAD OPTIONS
 		path /rest/oauth2-credential*
 	}
+	@duplicatiWebhooksNoMtls {
+		path /webhook/duplicati/* /webhook-test/duplicati/*
+		expression {tls_client_fingerprint} == "" && {tls_client_serial} == "" && {tls_client_subject} == ""
+	}
+	@duplicatiWebhooksMtls {
+		path /webhook/duplicati/* /webhook-test/duplicati/*
+		expression {tls_client_fingerprint} != "" || {tls_client_serial} != "" || {tls_client_subject} != ""
+	}
 	# Allow Telegram to call only the Scanservjs token reissue webhook without mTLS.
 	@telegramReissueWebhook {
 		method POST
@@ -345,6 +353,12 @@ workflow.{$CADDY_SUBDOMAIN} {
 			import n8n_upstream
 		}
 		handle @oauth2Credential {
+			import n8n_upstream
+		}
+		handle @duplicatiWebhooksNoMtls {
+			respond "mTLS required for duplicati webhooks" 403
+		}
+		handle @duplicatiWebhooksMtls {
 			import n8n_upstream
 		}
 		handle @telegramReissueWebhook {

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -277,11 +277,11 @@ landing.{$CADDY_SUBDOMAIN} {
 	}
 	@landingDuplicatiStatus {
 		method GET HEAD
-		path /duplicati/status
+		path /backup/status
 	}
 	@landingDuplicati {
 		method GET HEAD
-		path /duplicati/*
+		path /backup/*
 	}
 	route {
 		handle @landingApiMe {
@@ -291,12 +291,12 @@ landing.{$CADDY_SUBDOMAIN} {
 		}
 		handle @landingDuplicatiStatus {
 			import authelia_forward_auth
-			rewrite * /webhook/duplicati/duplicati-status-public
+			rewrite * /webhook/backup/status-public
 			import n8n_upstream
 		}
 		handle @landingDuplicati {
 			import authelia_forward_auth
-			uri strip_prefix /duplicati
+			uri strip_prefix /backup
 			import n8n_upstream
 		}
 		handle {

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -325,7 +325,7 @@ workflow.{$CADDY_SUBDOMAIN} {
 	# Allow Telegram to call only the Scanservjs token reissue webhook without mTLS.
 	@telegramReissueWebhook {
 		method POST
-		header X-Telegram-Bot-Api-Secret-Token {$TELEGRAM_WEBHOOK_SECRET}
+		expression {header.X-Telegram-Bot-Api-Secret-Token} == "{$TELEGRAM_WEBHOOK_SECRET}"
 		path /webhook/scanservjs/telegram/reissue /webhook-test/scanservjs/telegram/reissue
 	}
 	# Allow the external Alexa/Gemini integrations to call only their dedicated n8n webhook aliases without mTLS.

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -275,13 +275,13 @@ landing.{$CADDY_SUBDOMAIN} {
 		method GET HEAD
 		path /api/me
 	}
-	@landingDuplicatiStatus {
+	@landingBackupStatus {
 		method GET HEAD
 		path /backup/status
 	}
-	@landingDuplicati {
+	@landingBackupNames {
 		method GET HEAD
-		path /backup/*
+		path /backup/names
 	}
 	route {
 		handle @landingApiMe {
@@ -289,14 +289,14 @@ landing.{$CADDY_SUBDOMAIN} {
 			rewrite * /webhook/landing/api/me
 			import n8n_upstream
 		}
-		handle @landingDuplicatiStatus {
+		handle @landingBackupStatus {
 			import authelia_forward_auth
 			rewrite * /webhook/backup/status-public
 			import n8n_upstream
 		}
-		handle @landingDuplicati {
+		handle @landingBackupNames {
 			import authelia_forward_auth
-			uri strip_prefix /backup
+			rewrite * /webhook/backup/names
 			import n8n_upstream
 		}
 		handle {

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -275,6 +275,10 @@ landing.{$CADDY_SUBDOMAIN} {
 		method GET HEAD
 		path /api/me
 	}
+	@landingDuplicatiStatus {
+		method GET HEAD
+		path /duplicati/status
+	}
 	@landingDuplicati {
 		method GET HEAD
 		path /duplicati/*
@@ -283,6 +287,11 @@ landing.{$CADDY_SUBDOMAIN} {
 		handle @landingApiMe {
 			import authelia_forward_auth
 			rewrite * /webhook/landing/api/me
+			import n8n_upstream
+		}
+		handle @landingDuplicatiStatus {
+			import authelia_forward_auth
+			rewrite * /webhook/duplicati/duplicati-status-public
 			import n8n_upstream
 		}
 		handle @landingDuplicati {

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -325,7 +325,7 @@ workflow.{$CADDY_SUBDOMAIN} {
 	# Allow Telegram to call only the Scanservjs token reissue webhook without mTLS.
 	@telegramReissueWebhook {
 		method POST
-		header X-Telegram-Bot-Api-Secret-Token {}
+		header X-Telegram-Bot-Api-Secret-Token {$TELEGRAM_WEBHOOK_SECRET}
 		path /webhook/scanservjs/telegram/reissue /webhook-test/scanservjs/telegram/reissue
 	}
 	# Allow the external Alexa/Gemini integrations to call only their dedicated n8n webhook aliases without mTLS.

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -325,7 +325,7 @@ workflow.{$CADDY_SUBDOMAIN} {
 	# Allow Telegram to call only the Scanservjs token reissue webhook without mTLS.
 	@telegramReissueWebhook {
 		method POST
-		expression {header.X-Telegram-Bot-Api-Secret-Token} == "{$TELEGRAM_WEBHOOK_SECRET}"
+		header X-Telegram-Bot-Api-Secret-Token {}
 		path /webhook/scanservjs/telegram/reissue /webhook-test/scanservjs/telegram/reissue
 	}
 	# Allow the external Alexa/Gemini integrations to call only their dedicated n8n webhook aliases without mTLS.

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -285,7 +285,7 @@ landing.{$CADDY_SUBDOMAIN} {
 			rewrite * /webhook/landing/api/me
 			import n8n_upstream
 		}
-		handle @landingDuplicati {
+		handle_path @landingDuplicati {
 			import authelia_forward_auth
 			import n8n_upstream
 		}

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -275,10 +275,18 @@ landing.{$CADDY_SUBDOMAIN} {
 		method GET HEAD
 		path /api/me
 	}
+	@landingDuplicati {
+		method GET HEAD
+		path /duplicati/*
+	}
 	route {
 		handle @landingApiMe {
 			import authelia_forward_auth
 			rewrite * /webhook/landing/api/me
+			import n8n_upstream
+		}
+		handle @landingDuplicati {
+			import authelia_forward_auth
 			import n8n_upstream
 		}
 		handle {

--- a/scripts/test-auth-endpoints-e2e.sh
+++ b/scripts/test-auth-endpoints-e2e.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="$ROOT_DIR/tests/e2e/docker-compose.e2e.yml"
+BASE_URL="http://127.0.0.1:18080"
+
+cleanup() {
+  docker compose -f "$COMPOSE_FILE" down -v --remove-orphans >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+req_code() {
+  local method="$1" host="$2" path="$3" auth="$4" extra_header="${5:-}"
+  local -a args=( -sS -o /dev/null -w "%{http_code}" -X "$method" -H "Host: $host" )
+  if [[ "$auth" == "auth" ]]; then
+    args+=( -H "X-Test-Auth: allow" )
+  fi
+  if [[ -n "$extra_header" ]]; then
+    args+=( -H "$extra_header" )
+  fi
+  curl "${args[@]}" "$BASE_URL$path"
+}
+
+req_header() {
+  local method="$1" host="$2" path="$3" auth="$4" header_name="$5" extra_header="${6:-}"
+  local -a args=( -sS -D - -o /dev/null -X "$method" -H "Host: $host" )
+  if [[ "$auth" == "auth" ]]; then
+    args+=( -H "X-Test-Auth: allow" )
+  fi
+  if [[ -n "$extra_header" ]]; then
+    args+=( -H "$extra_header" )
+  fi
+  curl "${args[@]}" "$BASE_URL$path" | awk -v h="$header_name" 'BEGIN{IGNORECASE=1} $0 ~ "^"h":" {print; found=1} END{if(!found) exit 1}'
+}
+
+assert_eq() {
+  local got="$1" want="$2" msg="$3"
+  if [[ "$got" != "$want" ]]; then
+    echo "FAIL: $msg (got=$got want=$want)" >&2
+    exit 1
+  fi
+  echo "OK: $msg -> $got"
+}
+
+assert_no_upstream_header() {
+  local method="$1" host="$2" path="$3" auth="$4"
+  if req_header "$method" "$host" "$path" "$auth" "X-Upstream" >/dev/null 2>&1; then
+    echo "FAIL: unexpected upstream proxy for $host$path" >&2
+    exit 1
+  fi
+  echo "OK: no upstream proxy header for $host$path"
+}
+
+echo "Starting isolated E2E stack..."
+docker compose -f "$COMPOSE_FILE" up -d --wait
+
+# landing.* protected endpoints
+assert_eq "$(req_code GET landing.test /backup/status none)" "401" "landing /backup/status requires auth"
+assert_eq "$(req_code GET landing.test /backup/status auth)" "200" "landing /backup/status works with auth"
+assert_eq "$(req_code GET landing.test /backup/names none)" "401" "landing /backup/names requires auth"
+assert_eq "$(req_code GET landing.test /backup/names auth)" "200" "landing /backup/names works with auth"
+assert_eq "$(req_code GET landing.test /api/me none)" "401" "landing /api/me requires auth"
+assert_eq "$(req_code GET landing.test /api/me auth)" "200" "landing /api/me works with auth"
+
+# Ensure no broad /backup/* passthrough remains
+assert_eq "$(req_code GET landing.test /backup/rest/workflows auth)" "404" "landing /backup/rest/workflows is not proxied"
+assert_no_upstream_header GET landing.test /backup/rest/workflows auth
+
+# workflow.* protected webhook path
+assert_eq "$(req_code POST workflow.test /webhook/protected none)" "401" "workflow protected webhook requires auth without mTLS/exception"
+assert_eq "$(req_code POST workflow.test /webhook/protected auth)" "200" "workflow protected webhook works with auth"
+
+# Explicit Telegram exception (no auth but header secret)
+assert_eq "$(req_code POST workflow.test /webhook/scanservjs/telegram/reissue none "X-Telegram-Bot-Api-Secret-Token: test-telegram-secret")" "200" "telegram exception works without auth when secret header matches"
+assert_eq "$(req_code POST workflow.test /webhook/scanservjs/telegram/reissue none)" "401" "telegram path without secret remains protected"
+
+echo "All E2E auth endpoint checks passed."

--- a/scripts/test-auth-protected-endpoints.sh
+++ b/scripts/test-auth-protected-endpoints.sh
@@ -13,10 +13,20 @@ fail() {
   exit 1
 }
 
+has_fixed_string() {
+  local pattern="$1"
+  local file="$2"
+  if command -v rg >/dev/null 2>&1; then
+    rg -n --fixed-strings "$pattern" "$file" >/dev/null
+  else
+    grep -nF -- "$pattern" "$file" >/dev/null
+  fi
+}
+
 require_pattern() {
   local pattern="$1"
   local msg="$2"
-  if ! rg -n --fixed-strings "$pattern" "$CADDYFILE" >/dev/null; then
+  if ! has_fixed_string "$pattern" "$CADDYFILE"; then
     fail "$msg"
   fi
 }
@@ -24,7 +34,7 @@ require_pattern() {
 forbid_pattern() {
   local pattern="$1"
   local msg="$2"
-  if rg -n --fixed-strings "$pattern" "$CADDYFILE" >/dev/null; then
+  if has_fixed_string "$pattern" "$CADDYFILE"; then
     fail "$msg"
   fi
 }

--- a/scripts/test-auth-protected-endpoints.sh
+++ b/scripts/test-auth-protected-endpoints.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CADDYFILE="${1:-caddy/Caddyfile}"
+
+if [[ ! -f "$CADDYFILE" ]]; then
+  echo "ERROR: Caddyfile not found: $CADDYFILE" >&2
+  exit 1
+fi
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_pattern() {
+  local pattern="$1"
+  local msg="$2"
+  if ! rg -n --fixed-strings "$pattern" "$CADDYFILE" >/dev/null; then
+    fail "$msg"
+  fi
+}
+
+forbid_pattern() {
+  local pattern="$1"
+  local msg="$2"
+  if rg -n --fixed-strings "$pattern" "$CADDYFILE" >/dev/null; then
+    fail "$msg"
+  fi
+}
+
+# Landing host must expose only narrow backup aliases and protect them via Authelia.
+require_pattern "path /backup/status" "Missing landing alias /backup/status"
+require_pattern "path /backup/names" "Missing landing alias /backup/names"
+forbid_pattern "path /backup/*" "Broad /backup/* alias is forbidden on landing host"
+require_pattern "rewrite * /webhook/backup/status-public" "Missing rewrite for /backup/status"
+require_pattern "rewrite * /webhook/backup/names" "Missing rewrite for /backup/names"
+require_pattern "handle @landingBackupStatus {" "Missing landingBackupStatus handle"
+require_pattern "handle @landingBackupNames {" "Missing landingBackupNames handle"
+
+# Workflow host webhook protections must remain explicit.
+require_pattern 'header X-Telegram-Bot-Api-Secret-Token {$TELEGRAM_WEBHOOK_SECRET}' 'Missing Telegram secret header matcher'
+require_pattern "path /webhook/scanservjs/telegram/reissue /webhook-test/scanservjs/telegram/reissue" "Missing Telegram webhook path matcher"
+require_pattern "handle @webhooksAuthelia {" "Missing Authelia webhook handling branch"
+require_pattern "import authelia_forward_auth" "Missing authelia_forward_auth import"
+
+# Quick structural sanity for webhook mTLS split (must both exist).
+require_pattern "@webhooksMtls {" "Missing mTLS webhook matcher"
+require_pattern "@webhooksAuthelia {" "Missing non-mTLS webhook matcher"
+
+echo "Auth endpoint policy checks passed: $CADDYFILE"

--- a/site/landingpage/app.js
+++ b/site/landingpage/app.js
@@ -86,6 +86,49 @@ function renderFallback(error) {
   rolePill.textContent = "family";
 }
 
+function renderBackupStatus(data) {
+  const target = document.getElementById("backup-status");
+  if (!target) return;
+
+  const map = {
+    ok: "Backup OK",
+    warn: "Backup mit Warnungen",
+    error: "Backup fehlgeschlagen",
+    unknown: "Backupstatus unbekannt",
+  };
+
+  const status = data?.status || "unknown";
+  const label = map[status] || map.unknown;
+  const checkedAt = data?.checkedAt ? new Date(data.checkedAt).toLocaleString("de-DE") : "keine Daten";
+  const backupName = data?.backupName ? ` (${data.backupName})` : "";
+
+  target.textContent = `${label}${backupName} • Stand: ${checkedAt}`;
+}
+
+async function loadBackupStatus() {
+  try {
+    const response = await fetch("/duplicati/webhook/duplicati-status-public", {
+      credentials: "same-origin",
+      headers: {
+        Accept: "application/json",
+      },
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+
+    const payload = await response.json();
+    renderBackupStatus(payload);
+  } catch (error) {
+    const target = document.getElementById("backup-status");
+    if (target) {
+      target.textContent = `Backupstatus konnte nicht geladen werden (${error instanceof Error ? error.message : String(error)})`;
+    }
+  }
+}
+
 async function loadProfile() {
   try {
     const response = await fetch("/api/me", {
@@ -110,3 +153,4 @@ async function loadProfile() {
 initializeThemeToggle();
 hydrateLinks();
 loadProfile();
+loadBackupStatus();

--- a/site/landingpage/app.js
+++ b/site/landingpage/app.js
@@ -107,7 +107,7 @@ function renderBackupStatus(data) {
 
 async function loadBackupStatus() {
   try {
-    const response = await fetch("/duplicati/webhook/duplicati/duplicati-status-public", {
+    const response = await fetch("/duplicati/status", {
       credentials: "same-origin",
       headers: {
         Accept: "application/json",

--- a/site/landingpage/app.js
+++ b/site/landingpage/app.js
@@ -107,7 +107,7 @@ function renderBackupStatus(data) {
 
 async function loadBackupStatus() {
   try {
-    const response = await fetch("/duplicati/status", {
+    const response = await fetch("/backup/status", {
       credentials: "same-origin",
       headers: {
         Accept: "application/json",

--- a/site/landingpage/app.js
+++ b/site/landingpage/app.js
@@ -86,28 +86,52 @@ function renderFallback(error) {
   rolePill.textContent = "family";
 }
 
-function renderBackupStatus(data) {
-  const target = document.getElementById("backup-status");
-  if (!target) return;
-
+function mapStatusLabel(status) {
   const map = {
     ok: "Backup OK",
     warn: "Backup mit Warnungen",
     error: "Backup fehlgeschlagen",
     unknown: "Backupstatus unbekannt",
   };
+  return map[status] || map.unknown;
+}
 
-  const status = data?.status || "unknown";
-  const label = map[status] || map.unknown;
-  const checkedAt = data?.checkedAt ? new Date(data.checkedAt).toLocaleString("de-DE") : "keine Daten";
-  const backupName = data?.backupName ? ` (${data.backupName})` : "";
+function renderBackupStatusList(payload) {
+  const statusTarget = document.getElementById("backup-status");
+  const listTarget = document.getElementById("backup-list");
+  if (!statusTarget || !listTarget) return;
 
-  target.textContent = `${label}${backupName} • Stand: ${checkedAt}`;
+  const backups = Array.isArray(payload?.backups) ? payload.backups : [];
+
+  if (!backups.length) {
+    statusTarget.textContent = "Keine Backupdaten vorhanden.";
+    listTarget.innerHTML = "";
+    return;
+  }
+
+  const latestTs = backups
+    .map((b) => (b.lastCheckedAt ? Date.parse(b.lastCheckedAt) : 0))
+    .reduce((max, ts) => (ts > max ? ts : max), 0);
+  const latestText = latestTs ? new Date(latestTs).toLocaleString("de-DE") : "keine Daten";
+
+  statusTarget.textContent = `Backups: ${backups.length} • Letztes Update: ${latestText}`;
+
+  listTarget.innerHTML = backups
+    .map((backup) => {
+      const name = backup.backupName || "unbekannt";
+      const label = mapStatusLabel(backup.status);
+      const checkedAt = backup.lastCheckedAt ? new Date(backup.lastCheckedAt).toLocaleString("de-DE") : "keine Daten";
+      return `<li><strong>${name}</strong>: ${label} • Stand: ${checkedAt}</li>`;
+    })
+    .join("");
 }
 
 async function loadBackupStatus() {
+  const target = document.getElementById("backup-status");
+  const listTarget = document.getElementById("backup-list");
+
   try {
-    const response = await fetch("/backup/status", {
+    const response = await fetch("/backup/names", {
       credentials: "same-origin",
       headers: {
         Accept: "application/json",
@@ -119,12 +143,20 @@ async function loadBackupStatus() {
       throw new Error(`HTTP ${response.status}`);
     }
 
+    const contentType = response.headers.get("content-type") || "";
+    if (!contentType.includes("application/json")) {
+      const text = await response.text();
+      throw new Error(`Unerwartete Antwort (${contentType || "kein Content-Type"}): ${text.slice(0, 60)}`);
+    }
+
     const payload = await response.json();
-    renderBackupStatus(payload);
+    renderBackupStatusList(payload);
   } catch (error) {
-    const target = document.getElementById("backup-status");
     if (target) {
       target.textContent = `Backupstatus konnte nicht geladen werden (${error instanceof Error ? error.message : String(error)})`;
+    }
+    if (listTarget) {
+      listTarget.innerHTML = "";
     }
   }
 }

--- a/site/landingpage/app.js
+++ b/site/landingpage/app.js
@@ -107,7 +107,7 @@ function renderBackupStatus(data) {
 
 async function loadBackupStatus() {
   try {
-    const response = await fetch("/duplicati/webhook/duplicati-status-public", {
+    const response = await fetch("/duplicati/webhook/duplicati/duplicati-status-public", {
       credentials: "same-origin",
       headers: {
         Accept: "application/json",

--- a/site/landingpage/app.js
+++ b/site/landingpage/app.js
@@ -105,7 +105,7 @@ function renderBackupStatusList(payload) {
 
   if (!backups.length) {
     statusTarget.textContent = "Keine Backupdaten vorhanden.";
-    listTarget.innerHTML = "";
+    listTarget.replaceChildren();
     return;
   }
 
@@ -116,14 +116,19 @@ function renderBackupStatusList(payload) {
 
   statusTarget.textContent = `Backups: ${backups.length} • Letztes Update: ${latestText}`;
 
-  listTarget.innerHTML = backups
-    .map((backup) => {
-      const name = backup.backupName || "unbekannt";
-      const label = mapStatusLabel(backup.status);
-      const checkedAt = backup.lastCheckedAt ? new Date(backup.lastCheckedAt).toLocaleString("de-DE") : "keine Daten";
-      return `<li><strong>${name}</strong>: ${label} • Stand: ${checkedAt}</li>`;
-    })
-    .join("");
+  listTarget.replaceChildren();
+  backups.forEach((backup) => {
+    const name = backup.backupName || "unbekannt";
+    const label = mapStatusLabel(backup.status);
+    const checkedAt = backup.lastCheckedAt ? new Date(backup.lastCheckedAt).toLocaleString("de-DE") : "keine Daten";
+
+    const li = document.createElement("li");
+    const strong = document.createElement("strong");
+    strong.textContent = name;
+    li.appendChild(strong);
+    li.appendChild(document.createTextNode(`: ${label} • Stand: ${checkedAt}`));
+    listTarget.appendChild(li);
+  });
 }
 
 async function loadBackupStatus() {
@@ -146,7 +151,11 @@ async function loadBackupStatus() {
     const contentType = response.headers.get("content-type") || "";
     if (!contentType.includes("application/json")) {
       const text = await response.text();
-      throw new Error(`Unerwartete Antwort (${contentType || "kein Content-Type"}): ${text.slice(0, 60)}`);
+      throw new Error(
+        `Unerwartete Antwort (${contentType || "kein Content-Type"}). ` +
+        `Haeufige Ursache: Landing/Proxy liefert HTML statt /backup/names-JSON. ` +
+        `Vorschau: ${text.slice(0, 80)}`
+      );
     }
 
     const payload = await response.json();
@@ -156,7 +165,7 @@ async function loadBackupStatus() {
       target.textContent = `Backupstatus konnte nicht geladen werden (${error instanceof Error ? error.message : String(error)})`;
     }
     if (listTarget) {
-      listTarget.innerHTML = "";
+      listTarget.replaceChildren();
     }
   }
 }

--- a/site/landingpage/index.html
+++ b/site/landingpage/index.html
@@ -131,6 +131,7 @@
           <h2>Hinweis</h2>
         </div>
         <p id="backup-status">Backup-Status wird geladen ...</p>
+        <ul id="backup-list"></ul>
         <p>
           Diese Seite blendet nur Links ein oder aus. Die Zielsysteme muessen weiterhin selbst ueber
           Authelia, mTLS oder eigene Anmeldung geschuetzt bleiben.

--- a/site/landingpage/index.html
+++ b/site/landingpage/index.html
@@ -130,6 +130,7 @@
         <div class="section-head">
           <h2>Hinweis</h2>
         </div>
+        <p id="backup-status">Backup-Status wird geladen ...</p>
         <p>
           Diese Seite blendet nur Links ein oder aus. Die Zielsysteme muessen weiterhin selbst ueber
           Authelia, mTLS oder eigene Anmeldung geschuetzt bleiben.

--- a/tests/e2e/Caddyfile
+++ b/tests/e2e/Caddyfile
@@ -1,0 +1,116 @@
+{
+  auto_https off
+  admin off
+}
+
+(authelia_forward_auth) {
+  forward_auth authelia:9091 {
+    uri /api/authz/forward-auth
+    copy_headers Remote-User Remote-Groups Remote-Email Remote-Name
+  }
+}
+
+(n8n_upstream) {
+  reverse_proxy http://n8n-mock:5678
+}
+
+http://landing.test {
+  encode gzip
+
+  @landingApiMe {
+    method GET HEAD
+    path /api/me
+  }
+
+  @landingBackupStatus {
+    method GET HEAD
+    path /backup/status
+  }
+
+  @landingBackupNames {
+    method GET HEAD
+    path /backup/names
+  }
+
+  route {
+    handle @landingApiMe {
+      import authelia_forward_auth
+      rewrite * /webhook/landing/api/me
+      import n8n_upstream
+    }
+
+    handle @landingBackupStatus {
+      import authelia_forward_auth
+      rewrite * /webhook/backup/status-public
+      import n8n_upstream
+    }
+
+    handle @landingBackupNames {
+      import authelia_forward_auth
+      rewrite * /webhook/backup/names
+      import n8n_upstream
+    }
+
+    handle {
+      import authelia_forward_auth
+      respond "landing static" 404
+    }
+  }
+}
+
+http://workflow.test {
+  @apiMe {
+    method GET HEAD
+    path /api/me
+  }
+
+  @oauth2Credential {
+    method GET HEAD OPTIONS
+    path /rest/oauth2-credential*
+  }
+
+  @telegramReissueWebhook {
+    method POST
+    header X-Telegram-Bot-Api-Secret-Token {$TELEGRAM_WEBHOOK_SECRET}
+    path /webhook/scanservjs/telegram/reissue /webhook-test/scanservjs/telegram/reissue
+  }
+
+  @alexaGeminiWebhook {
+    method POST
+    path /webhook/antannah/alexa-gemini /webhook-test/antannah/alexa-gemini /webhook/sven/alexa-gemini /webhook-test/sven/alexa-gemini
+  }
+
+  # In this HTTP-only e2e setup, mTLS vars are empty, so all webhooks go via Authelia unless explicit exceptions above.
+  @webhooksAuthelia {
+    path /webhook/* /webhook-test/*
+  }
+
+  route {
+    handle @apiMe {
+      import authelia_forward_auth
+      rewrite * /webhook/landing/api/me
+      import n8n_upstream
+    }
+
+    handle @oauth2Credential {
+      import n8n_upstream
+    }
+
+    handle @telegramReissueWebhook {
+      import n8n_upstream
+    }
+
+    handle @alexaGeminiWebhook {
+      import n8n_upstream
+    }
+
+    handle @webhooksAuthelia {
+      import authelia_forward_auth
+      import n8n_upstream
+    }
+
+    handle {
+      respond "workflow fallback" 404
+    }
+  }
+}

--- a/tests/e2e/docker-compose.e2e.yml
+++ b/tests/e2e/docker-compose.e2e.yml
@@ -1,28 +1,28 @@
 name: caddy-rproxy-e2e
 
 services:
-  caddy-e2e:
-    image: caddy:2.11.3@sha256:ec18ee54aab3315c22e25f3b2babda73ff8007d39b13b3bd1bfffa2f0444c7d9
-    environment:
-      TELEGRAM_WEBHOOK_SECRET: test-telegram-secret
-    volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile:ro
-    ports:
-      - "18080:80"
-    depends_on:
-      - authelia
-      - n8n-mock
-
   authelia:
     image: python:3.12-alpine
-    working_dir: /app
     volumes:
       - ./mock_auth.py:/app/mock_auth.py:ro
     command: ["python3", "/app/mock_auth.py"]
+    working_dir: /app
+
+  caddy-e2e:
+    image: caddy:2.11.3@sha256:ec18ee54aab3315c22e25f3b2babda73ff8007d39b13b3bd1bfffa2f0444c7d9
+    depends_on:
+      - authelia
+      - n8n-mock
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+    environment:
+      TELEGRAM_WEBHOOK_SECRET: test-telegram-secret
+    ports:
+      - "127.0.0.1:18080:80"
 
   n8n-mock:
     image: python:3.12-alpine
-    working_dir: /app
     volumes:
       - ./mock_n8n.py:/app/mock_n8n.py:ro
     command: ["python3", "/app/mock_n8n.py"]
+    working_dir: /app

--- a/tests/e2e/docker-compose.e2e.yml
+++ b/tests/e2e/docker-compose.e2e.yml
@@ -1,0 +1,28 @@
+name: caddy-rproxy-e2e
+
+services:
+  caddy-e2e:
+    image: caddy:2.11.3@sha256:ec18ee54aab3315c22e25f3b2babda73ff8007d39b13b3bd1bfffa2f0444c7d9
+    environment:
+      TELEGRAM_WEBHOOK_SECRET: test-telegram-secret
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+    ports:
+      - "18080:80"
+    depends_on:
+      - authelia
+      - n8n-mock
+
+  authelia:
+    image: python:3.12-alpine
+    working_dir: /app
+    volumes:
+      - ./mock_auth.py:/app/mock_auth.py:ro
+    command: ["python3", "/app/mock_auth.py"]
+
+  n8n-mock:
+    image: python:3.12-alpine
+    working_dir: /app
+    volumes:
+      - ./mock_n8n.py:/app/mock_n8n.py:ro
+    command: ["python3", "/app/mock_n8n.py"]

--- a/tests/e2e/mock_auth.py
+++ b/tests/e2e/mock_auth.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self._handle()
+
+    def do_POST(self):
+        self._handle()
+
+    def _handle(self):
+        if self.path != "/api/authz/forward-auth":
+            self.send_response(404)
+            self.end_headers()
+            self.wfile.write(b"not found")
+            return
+
+        allowed = self.headers.get("X-Test-Auth", "") == "allow"
+        if not allowed:
+            self.send_response(401)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(b"unauthorized")
+            return
+
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Remote-User", "test-user")
+        self.send_header("Remote-Groups", "admins")
+        self.send_header("Remote-Email", "test@example.com")
+        self.send_header("Remote-Name", "Test User")
+        self.end_headers()
+        self.wfile.write(b"ok")
+
+    def log_message(self, fmt, *args):
+        return
+
+if __name__ == "__main__":
+    HTTPServer(("0.0.0.0", 9091), Handler).serve_forever()

--- a/tests/e2e/mock_n8n.py
+++ b/tests/e2e/mock_n8n.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+class Handler(BaseHTTPRequestHandler):
+    def _send_json(self, code, payload):
+        data = json.dumps(payload).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("X-Upstream", "n8n-mock")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_GET(self):
+        self._handle()
+
+    def do_HEAD(self):
+        self._handle(head=True)
+
+    def do_POST(self):
+        self._handle()
+
+    def _handle(self, head=False):
+        path = self.path
+        if path == "/webhook/backup/status-public":
+            payload = {"status": "ok", "backupName": "paperless", "checkedAt": "2026-05-23T00:00:00Z"}
+            if head:
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("X-Upstream", "n8n-mock")
+                self.end_headers()
+            else:
+                self._send_json(200, payload)
+            return
+
+        if path == "/webhook/backup/names":
+            payload = {"count": 1, "backupNames": ["paperless"], "backups": [{"backupName": "paperless", "status": "ok"}]}
+            if head:
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("X-Upstream", "n8n-mock")
+                self.end_headers()
+            else:
+                self._send_json(200, payload)
+            return
+
+        if path == "/webhook/landing/api/me":
+            payload = {"user": "test-user", "groups": ["admins"], "role": "admin"}
+            if head:
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("X-Upstream", "n8n-mock")
+                self.end_headers()
+            else:
+                self._send_json(200, payload)
+            return
+
+        # Generic webhook sink for protected workflow endpoints.
+        if path.startswith("/webhook/") or path.startswith("/webhook-test/") or path.startswith("/rest/oauth2-credential"):
+            payload = {"ok": True, "path": path, "method": self.command}
+            if head:
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("X-Upstream", "n8n-mock")
+                self.end_headers()
+            else:
+                self._send_json(200, payload)
+            return
+
+        self._send_json(404, {"error": "not found", "path": path})
+
+    def log_message(self, fmt, *args):
+        return
+
+if __name__ == "__main__":
+    HTTPServer(("0.0.0.0", 5678), Handler).serve_forever()


### PR DESCRIPTION
## What changed
- Added a Duplicati status section to the landing page.
- Added a `/duplicati/*` path in Caddy so the landing page can reach the Duplicati status webhook without rewrites.
- The landing page now fetches the public Duplicati status endpoint and renders the latest backup state.

## Why
- The landing page should expose the current backup status without needing to know individual backup jobs in detail.
- The Duplicati workflow already normalizes and stores the status in n8n, so the landing page can consume a single public JSON endpoint.

## Impact
- Users visiting the landing page can see the latest Duplicati status directly.
- The implementation keeps the Duplicati-related URLs grouped under a dedicated path.

## Validation
- Branch committed and pushed: `feat/landing-backup-status`
- Caddy and landing page changes reviewed in the repo diff
- No runtime tests were executed in this repo beyond the code integration already completed in n8n
