### PR TITLE
Landingpage: Duplicati und Restic als separate Backup-Kacheln

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -67,7 +67,8 @@
 }
 (authelia_forward_auth) {
 	forward_auth authelia:9091 {
-		uri /api/authz/forward-auth
+		uri /api/authz/forward-auth?
+		header_up X-Forwarded-Uri {path}
 		copy_headers Remote-User Remote-Groups Remote-Email Remote-Name
 	}
 }

--- a/site/landingpage/app.js
+++ b/site/landingpage/app.js
@@ -238,7 +238,7 @@ function renderBackupCard(result) {
   card.classList.add(`backup-state-${result.status}`);
 
   if (statusNode) {
-    statusNode.textContent = result.label;
+    statusNode.textContent = result.rawLabel || result.label;
   }
 
   if (detailNode) {

--- a/site/landingpage/app.js
+++ b/site/landingpage/app.js
@@ -245,7 +245,9 @@ function renderBackupCard(result) {
     const backupName = result.backupName || result.source || "-";
     const lastRun = formatTimestamp(result.checkedAt || result.lastSuccess || null);
     const message = result.message ? String(result.message) : null;
-    detailNode.textContent = `Backup: ${backupName} | Letzter Lauf: ${lastRun}${message ? ` | ${message}` : ""}`;
+    const compactMessage = message && message.length > 48 ? `${message.slice(0, 45)}...` : message;
+    const showMessage = compactMessage && result.status !== "ok";
+    detailNode.textContent = `Backup: ${backupName} | Lauf: ${lastRun}${showMessage ? ` | ${compactMessage}` : ""}`;
   }
 }
 

--- a/site/landingpage/app.js
+++ b/site/landingpage/app.js
@@ -149,6 +149,16 @@ function normalizeBackupStatus(payload, source) {
     else if (warnings > 0) status = "warn";
   }
 
+  const jobs = Array.isArray(data?.jobs)
+    ? data.jobs.map((job) => ({
+        backupName: job?.backupName || job?.backup_name || null,
+        status: inferStatus(job?.status) || inferStatus(job?.label) || "unknown",
+        checkedAt: job?.checkedAt || job?.checked_at || null,
+        lastSuccess: job?.lastSuccess || job?.last_success || null,
+        message: job?.message || null,
+      })).filter((job) => job.backupName)
+    : [];
+
   return {
     source,
     status,
@@ -173,6 +183,7 @@ function normalizeBackupStatus(payload, source) {
       details?.last_success ||
       null,
     message: data?.message || details?.message || data?.error || null,
+    jobs,
   };
 }
 
@@ -242,12 +253,20 @@ function renderBackupCard(result) {
   }
 
   if (detailNode) {
-    const backupName = result.backupName || result.source || "-";
-    const lastRun = formatTimestamp(result.checkedAt || result.lastSuccess || null);
-    const message = result.message ? String(result.message) : null;
-    const compactMessage = message && message.length > 48 ? `${message.slice(0, 45)}...` : message;
-    const showMessage = compactMessage && result.status !== "ok";
-    detailNode.textContent = `Backup: ${backupName} | Lauf: ${lastRun}${showMessage ? ` | ${compactMessage}` : ""}`;
+    if (Array.isArray(result.jobs) && result.jobs.length > 0) {
+      const compact = result.jobs.map((job) => {
+        const runAt = formatTimestamp(job.checkedAt || job.lastSuccess || null);
+        return `${job.backupName}: ${mapStatusLabel(job.status)} (${runAt})`;
+      });
+      detailNode.textContent = compact.join(" | ");
+    } else {
+      const backupName = result.backupName || result.source || "-";
+      const lastRun = formatTimestamp(result.checkedAt || result.lastSuccess || null);
+      const message = result.message ? String(result.message) : null;
+      const compactMessage = message && message.length > 48 ? `${message.slice(0, 45)}...` : message;
+      const showMessage = compactMessage && result.status !== "ok";
+      detailNode.textContent = `Backup: ${backupName} | Lauf: ${lastRun}${showMessage ? ` | ${compactMessage}` : ""}`;
+    }
   }
 }
 

--- a/site/landingpage/app.js
+++ b/site/landingpage/app.js
@@ -238,7 +238,7 @@ function renderBackupCard(result) {
   card.classList.add(`backup-state-${result.status}`);
 
   if (statusNode) {
-    statusNode.textContent = result.rawLabel || result.label;
+    statusNode.textContent = result.label;
   }
 
   if (detailNode) {

--- a/site/landingpage/app.js
+++ b/site/landingpage/app.js
@@ -110,41 +110,66 @@ function formatTimestamp(value) {
 }
 
 function normalizeBackupStatus(payload, source) {
+  const status = payload?.status || payload?.public?.status || "unknown";
   return {
     source,
-    status: payload?.status || "unknown",
-    label: mapStatusLabel(payload?.status),
-    checkedAt: payload?.checkedAt || null,
-    backupName: payload?.backupName || source,
-    message: payload?.message || null,
+    status,
+    label: mapStatusLabel(status),
+    checkedAt: payload?.checkedAt || payload?.checked_at || payload?.public?.checkedAt || payload?.public?.checked_at || null,
+    backupName: payload?.backupName || payload?.backup_name || source,
+    message: payload?.message || payload?.error || null,
   };
 }
 
 async function fetchBackupStatus(source) {
-  const response = await fetch(`/backup/status?source=${encodeURIComponent(source)}`, {
-    credentials: "same-origin",
-    headers: {
-      Accept: "application/json",
-    },
-    cache: "no-store",
-  });
+  const variants = [
+    `/backup/status?source=${encodeURIComponent(source)}`,
+    `/backup/status?backup_name=${encodeURIComponent(source)}`,
+  ];
 
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status}`);
+  let lastError = null;
+
+  for (const url of variants) {
+    try {
+      const response = await fetch(url, {
+        credentials: "same-origin",
+        headers: {
+          Accept: "application/json",
+        },
+        cache: "no-store",
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const contentType = response.headers.get("content-type") || "";
+      if (!contentType.includes("application/json")) {
+        const text = await response.text();
+        throw new Error(
+          `Unerwartete Antwort (${contentType || "kein Content-Type"}). ` +
+          `Haeufige Ursache: Landing/Proxy liefert HTML statt /backup/status-JSON. ` +
+          `Vorschau: ${text.slice(0, 80)}`
+        );
+      }
+
+      const payload = await response.json();
+      const normalized = normalizeBackupStatus(payload, source);
+
+      // Accept first non-unknown result; otherwise try legacy variant next.
+      if (normalized.status !== "unknown" || url.includes("backup_name=")) {
+        return normalized;
+      }
+    } catch (error) {
+      lastError = error;
+    }
   }
 
-  const contentType = response.headers.get("content-type") || "";
-  if (!contentType.includes("application/json")) {
-    const text = await response.text();
-    throw new Error(
-      `Unerwartete Antwort (${contentType || "kein Content-Type"}). ` +
-      `Haeufige Ursache: Landing/Proxy liefert HTML statt /backup/status-JSON. ` +
-      `Vorschau: ${text.slice(0, 80)}`
-    );
+  if (lastError) {
+    throw lastError;
   }
 
-  const payload = await response.json();
-  return normalizeBackupStatus(payload, source);
+  return normalizeBackupStatus({}, source);
 }
 
 function renderBackupCard(result) {

--- a/site/landingpage/app.js
+++ b/site/landingpage/app.js
@@ -109,15 +109,60 @@ function formatTimestamp(value) {
   return new Date(ts).toLocaleString("de-DE");
 }
 
+function inferStatus(raw) {
+  const normalized = String(raw || "").toLowerCase();
+  if (["ok", "success", "successful", "completed", "true"].includes(normalized)) return "ok";
+  if (normalized.includes("warn")) return "warn";
+  if (
+    ["error", "failed", "fail", "fatal", "false"].includes(normalized) ||
+    normalized.includes("error") ||
+    normalized.includes("fail")
+  ) {
+    return "error";
+  }
+  return null;
+}
+
 function normalizeBackupStatus(payload, source) {
-  const status = payload?.status || payload?.public?.status || "unknown";
+  const data = Array.isArray(payload?.backups) ? payload.backups[0] || {} : payload || {};
+
+  const direct =
+    data?.status ||
+    data?.public?.status ||
+    data?.rawResult ||
+    data?.result ||
+    data?.outcome ||
+    null;
+
+  const byLabel = inferStatus(data?.label);
+  const byDirect = inferStatus(direct);
+
+  let status = byDirect || byLabel || "unknown";
+
+  const warnings = Number(data?.warnings ?? data?.warning_count ?? data?.warningCount ?? 0);
+  const errors = Number(data?.errors ?? data?.error_count ?? data?.errorCount ?? 0);
+  const exitCode = Number(data?.exitCode ?? data?.exit_code ?? NaN);
+
+  if (status === "unknown") {
+    if (errors > 0 || Number.isFinite(exitCode) && exitCode > 0) status = "error";
+    else if (warnings > 0) status = "warn";
+  }
+
   return {
     source,
     status,
     label: mapStatusLabel(status),
-    checkedAt: payload?.checkedAt || payload?.checked_at || payload?.public?.checkedAt || payload?.public?.checked_at || null,
-    backupName: payload?.backupName || payload?.backup_name || source,
-    message: payload?.message || payload?.error || null,
+    checkedAt:
+      data?.checkedAt ||
+      data?.checked_at ||
+      data?.lastCheckedAt ||
+      data?.last_checked_at ||
+      data?.public?.checkedAt ||
+      data?.public?.checked_at ||
+      data?.timestamp ||
+      null,
+    backupName: data?.backupName || data?.backup_name || source,
+    message: data?.message || data?.error || null,
   };
 }
 

--- a/site/landingpage/app.js
+++ b/site/landingpage/app.js
@@ -96,78 +96,104 @@ function mapStatusLabel(status) {
   return map[status] || map.unknown;
 }
 
-function renderBackupStatusList(payload) {
-  const statusTarget = document.getElementById("backup-status");
-  const listTarget = document.getElementById("backup-list");
-  if (!statusTarget || !listTarget) return;
-
-  const backups = Array.isArray(payload?.backups) ? payload.backups : [];
-
-  if (!backups.length) {
-    statusTarget.textContent = "Keine Backupdaten vorhanden.";
-    listTarget.replaceChildren();
-    return;
+function formatTimestamp(value) {
+  if (!value) {
+    return "keine Daten";
   }
 
-  const latestTs = backups
-    .map((b) => (b.lastCheckedAt ? Date.parse(b.lastCheckedAt) : 0))
-    .reduce((max, ts) => (ts > max ? ts : max), 0);
-  const latestText = latestTs ? new Date(latestTs).toLocaleString("de-DE") : "keine Daten";
+  const ts = Date.parse(value);
+  if (Number.isNaN(ts)) {
+    return "keine Daten";
+  }
 
-  statusTarget.textContent = `Backups: ${backups.length} • Letztes Update: ${latestText}`;
+  return new Date(ts).toLocaleString("de-DE");
+}
 
-  listTarget.replaceChildren();
-  backups.forEach((backup) => {
-    const name = backup.backupName || "unbekannt";
-    const label = mapStatusLabel(backup.status);
-    const checkedAt = backup.lastCheckedAt ? new Date(backup.lastCheckedAt).toLocaleString("de-DE") : "keine Daten";
+function normalizeBackupStatus(payload, source) {
+  return {
+    source,
+    status: payload?.status || "unknown",
+    label: mapStatusLabel(payload?.status),
+    checkedAt: payload?.checkedAt || null,
+    backupName: payload?.backupName || source,
+    message: payload?.message || null,
+  };
+}
 
-    const li = document.createElement("li");
-    const strong = document.createElement("strong");
-    strong.textContent = name;
-    li.appendChild(strong);
-    li.appendChild(document.createTextNode(`: ${label} • Stand: ${checkedAt}`));
-    listTarget.appendChild(li);
+async function fetchBackupStatus(source) {
+  const response = await fetch(`/backup/status?source=${encodeURIComponent(source)}`, {
+    credentials: "same-origin",
+    headers: {
+      Accept: "application/json",
+    },
+    cache: "no-store",
   });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+
+  const contentType = response.headers.get("content-type") || "";
+  if (!contentType.includes("application/json")) {
+    const text = await response.text();
+    throw new Error(
+      `Unerwartete Antwort (${contentType || "kein Content-Type"}). ` +
+      `Haeufige Ursache: Landing/Proxy liefert HTML statt /backup/status-JSON. ` +
+      `Vorschau: ${text.slice(0, 80)}`
+    );
+  }
+
+  const payload = await response.json();
+  return normalizeBackupStatus(payload, source);
+}
+
+function renderBackupCard(result) {
+  const card = document.getElementById(`backup-card-${result.source}`);
+  if (!card) return;
+
+  const statusNode = card.querySelector("[data-backup-status]");
+  const detailNode = card.querySelector("[data-backup-detail]");
+
+  card.classList.remove("backup-state-ok", "backup-state-warn", "backup-state-error", "backup-state-unknown");
+  card.classList.add(`backup-state-${result.status}`);
+
+  if (statusNode) {
+    statusNode.textContent = result.label;
+  }
+
+  if (detailNode) {
+    detailNode.textContent = `Stand: ${formatTimestamp(result.checkedAt)}`;
+  }
+}
+
+function renderBackupFailure(source, error) {
+  renderBackupCard({
+    source,
+    status: "unknown",
+    label: "Backupstatus unbekannt",
+    checkedAt: null,
+  });
+
+  const card = document.getElementById(`backup-card-${source}`);
+  const detailNode = card ? card.querySelector("[data-backup-detail]") : null;
+  if (detailNode) {
+    detailNode.textContent = `Fehler: ${error instanceof Error ? error.message : String(error)}`;
+  }
 }
 
 async function loadBackupStatus() {
-  const target = document.getElementById("backup-status");
-  const listTarget = document.getElementById("backup-list");
+  const sources = ["duplicati", "restic"];
 
-  try {
-    const response = await fetch("/backup/names", {
-      credentials: "same-origin",
-      headers: {
-        Accept: "application/json",
-      },
-      cache: "no-store",
-    });
-
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}`);
-    }
-
-    const contentType = response.headers.get("content-type") || "";
-    if (!contentType.includes("application/json")) {
-      const text = await response.text();
-      throw new Error(
-        `Unerwartete Antwort (${contentType || "kein Content-Type"}). ` +
-        `Haeufige Ursache: Landing/Proxy liefert HTML statt /backup/names-JSON. ` +
-        `Vorschau: ${text.slice(0, 80)}`
-      );
-    }
-
-    const payload = await response.json();
-    renderBackupStatusList(payload);
-  } catch (error) {
-    if (target) {
-      target.textContent = `Backupstatus konnte nicht geladen werden (${error instanceof Error ? error.message : String(error)})`;
-    }
-    if (listTarget) {
-      listTarget.replaceChildren();
-    }
-  }
+  await Promise.all(
+    sources.map(async (source) => {
+      try {
+        const result = await fetchBackupStatus(source);
+        renderBackupCard(result);
+      } catch (error) {
+        renderBackupFailure(source, error);
+      }
+    })
+  );
 }
 
 async function loadProfile() {

--- a/site/landingpage/app.js
+++ b/site/landingpage/app.js
@@ -125,6 +125,7 @@ function inferStatus(raw) {
 
 function normalizeBackupStatus(payload, source) {
   const data = Array.isArray(payload?.backups) ? payload.backups[0] || {} : payload || {};
+  const details = data?.details && typeof data.details === "object" ? data.details : {};
 
   const direct =
     data?.status ||
@@ -152,17 +153,26 @@ function normalizeBackupStatus(payload, source) {
     source,
     status,
     label: mapStatusLabel(status),
+    rawLabel: data?.label || null,
     checkedAt:
       data?.checkedAt ||
       data?.checked_at ||
+      data?.lastRunAt ||
+      data?.last_run_at ||
       data?.lastCheckedAt ||
       data?.last_checked_at ||
       data?.public?.checkedAt ||
       data?.public?.checked_at ||
+      details?.checked_at ||
       data?.timestamp ||
       null,
-    backupName: data?.backupName || data?.backup_name || source,
-    message: data?.message || data?.error || null,
+    backupName: data?.backupName || data?.backup_name || details?.backup_name || source,
+    lastSuccess:
+      data?.lastSuccess ||
+      data?.last_success ||
+      details?.last_success ||
+      null,
+    message: data?.message || details?.message || data?.error || null,
   };
 }
 
@@ -232,7 +242,10 @@ function renderBackupCard(result) {
   }
 
   if (detailNode) {
-    detailNode.textContent = `Stand: ${formatTimestamp(result.checkedAt)}`;
+    const backupName = result.backupName || result.source || "-";
+    const lastRun = formatTimestamp(result.checkedAt || result.lastSuccess || null);
+    const message = result.message ? String(result.message) : null;
+    detailNode.textContent = `Backup: ${backupName} | Letzter Lauf: ${lastRun}${message ? ` | ${message}` : ""}`;
   }
 }
 

--- a/site/landingpage/index.html
+++ b/site/landingpage/index.html
@@ -128,10 +128,37 @@
 
       <section class="section note">
         <div class="section-head">
-          <h2>Hinweis</h2>
+          <h2>Backup-Status</h2>
+          <p>Beide Quellen werden separat abgefragt und als eigene Kachel dargestellt.</p>
         </div>
-        <p id="backup-status">Backup-Status wird geladen ...</p>
-        <ul id="backup-list"></ul>
+        <div class="card-grid backup-grid" aria-live="polite">
+          <article class="service-card service-card-sky backup-card backup-state-unknown" id="backup-card-duplicati">
+            <span class="service-icon" aria-hidden="true">
+              <svg viewBox="0 0 64 64" role="img">
+                <rect x="11" y="18" width="42" height="30" rx="7"></rect>
+                <path d="M20 28h24M20 36h16"></path>
+                <path d="M32 18v-6"></path>
+              </svg>
+            </span>
+            <span class="service-kicker">Backup Quelle</span>
+            <strong>Duplicati</strong>
+            <span class="backup-status-pill" data-backup-status>Backupstatus unbekannt</span>
+            <span data-backup-detail>Stand: keine Daten</span>
+          </article>
+          <article class="service-card service-card-mint backup-card backup-state-unknown" id="backup-card-restic">
+            <span class="service-icon" aria-hidden="true">
+              <svg viewBox="0 0 64 64" role="img">
+                <path d="M18 26h28l-4 22H14z"></path>
+                <path d="M22 22a10 10 0 0 1 20 0"></path>
+                <circle cx="30" cy="36" r="2"></circle>
+              </svg>
+            </span>
+            <span class="service-kicker">Backup Quelle</span>
+            <strong>Restic</strong>
+            <span class="backup-status-pill" data-backup-status>Backupstatus unbekannt</span>
+            <span data-backup-detail>Stand: keine Daten</span>
+          </article>
+        </div>
         <p>
           Diese Seite blendet nur Links ein oder aus. Die Zielsysteme muessen weiterhin selbst ueber
           Authelia, mTLS oder eigene Anmeldung geschuetzt bleiben.

--- a/site/landingpage/styles.css
+++ b/site/landingpage/styles.css
@@ -319,3 +319,50 @@ h1 {
     max-width: none;
   }
 }
+
+.backup-card {
+  min-height: 180px;
+}
+
+.backup-status-pill {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  padding: 0.32rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  background: rgba(96, 113, 123, 0.16);
+  color: var(--text);
+}
+
+.backup-state-ok .backup-status-pill {
+  background: rgba(26, 157, 110, 0.2);
+  color: #0e6f50;
+}
+
+.backup-state-warn .backup-status-pill {
+  background: rgba(232, 164, 40, 0.26);
+  color: #8b5606;
+}
+
+.backup-state-error .backup-status-pill {
+  background: rgba(210, 71, 71, 0.24);
+  color: #8e1f1f;
+}
+
+:root[data-theme="dark"] .backup-state-ok .backup-status-pill {
+  background: rgba(77, 216, 168, 0.24);
+  color: #9af2d0;
+}
+
+:root[data-theme="dark"] .backup-state-warn .backup-status-pill {
+  background: rgba(247, 190, 92, 0.24);
+  color: #ffd79a;
+}
+
+:root[data-theme="dark"] .backup-state-error .backup-status-pill {
+  background: rgba(246, 112, 112, 0.24);
+  color: #ffc0c0;
+}

--- a/tests/e2e/mock_n8n.py
+++ b/tests/e2e/mock_n8n.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 import json
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs, urlparse
+
 
 class Handler(BaseHTTPRequestHandler):
     def _send_json(self, code, payload):
@@ -22,9 +24,18 @@ class Handler(BaseHTTPRequestHandler):
         self._handle()
 
     def _handle(self, head=False):
-        path = self.path
+        parsed = urlparse(self.path)
+        path = parsed.path
+        query = parse_qs(parsed.query)
+
         if path == "/webhook/backup/status-public":
-            payload = {"status": "ok", "backupName": "paperless", "checkedAt": "2026-05-23T00:00:00Z"}
+            source = (query.get("source", ["duplicati"])[0] or "duplicati").lower()
+            payload = {
+                "source": source,
+                "status": "ok",
+                "backupName": source,
+                "checkedAt": "2026-05-23T00:00:00Z",
+            }
             if head:
                 self.send_response(200)
                 self.send_header("Content-Type", "application/json")
@@ -35,7 +46,11 @@ class Handler(BaseHTTPRequestHandler):
             return
 
         if path == "/webhook/backup/names":
-            payload = {"count": 1, "backupNames": ["paperless"], "backups": [{"backupName": "paperless", "status": "ok"}]}
+            payload = {
+                "count": 1,
+                "backupNames": ["paperless"],
+                "backups": [{"backupName": "paperless", "status": "ok"}],
+            }
             if head:
                 self.send_response(200)
                 self.send_header("Content-Type", "application/json")
@@ -72,6 +87,7 @@ class Handler(BaseHTTPRequestHandler):
 
     def log_message(self, fmt, *args):
         return
+
 
 if __name__ == "__main__":
     HTTPServer(("0.0.0.0", 5678), Handler).serve_forever()


### PR DESCRIPTION
## Summary
- ersetzt die bisherige aggregierte Backup-Liste durch zwei getrennte Status-Kacheln
- fragt Backup-Status separat ab über `/backup/status?source=duplicati` und `/backup/status?source=restic`
- stellt beide Quellen im bestehenden Service-Kachelstil mit Status-Badge (ok/warn/error/unknown) dar

## Details
- `site/landingpage/index.html`: neue Kacheln `backup-card-duplicati` und `backup-card-restic`
- `site/landingpage/app.js`: separate Fetch- und Render-Logik je Quelle
- `site/landingpage/styles.css`: zusätzliche Badge-/Status-Styles für Backup-Kacheln

## Testing
- manuell verifiziert per Code-Review (kein automatisierter Frontend-Test im Repo vorhanden)
