### PR TITLE
[codex] limit FHEM upstream concurrency

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -108,20 +108,17 @@
 		import fhem_transport
 	}
 }
-(fhem_upstream_cached) {
-	reverse_proxy https://fhem-fhem-1.network_backend_net:8083 {
-		header_down Cache-Control "public, max-age=2592000"
-		import fhem_client_cert_headers
-		import fhem_transport
-	}
+(fhem_static_long_cache) {
+	header Cache-Control "public, max-age=2592000"
+	root * /srv/fhem-www
+	uri strip_prefix /fhem
+	file_server
 }
-(fhem_upstream_with_auth_header_cached) {
-	reverse_proxy https://fhem-fhem-1.network_backend_net:8083 {
-		header_up Authorization {$FHEM_BASIC_AUTH_HEADER}
-		header_down Cache-Control "public, max-age=2592000"
-		import fhem_client_cert_headers
-		import fhem_transport
-	}
+(fhem_static_short_cache) {
+	header Cache-Control "public, max-age=3600"
+	root * /srv/fhem-www
+	uri strip_prefix /fhem
+	file_server
 }
 (logging_info) {
 	log {
@@ -157,22 +154,24 @@ fhem.{$CADDY_SUBDOMAIN} {
 	encode gzip
 
 	@fhem_images path /fhem/images/*
+	@fhem_static_short_cache path /fhem/codemirror/* /fhem/pgm2/*
 	route {
 		handle @fhem_images {
 			handle @missing_mTLS_cert {
 				import authelia_forward_auth
-				handle @fhem_basic_auth_secret_missing {
-					import fhem_upstream_cached
-				}
-				handle {
-					import fhem_upstream_with_auth_header_cached
-				}
-			}
-			handle @fhem_basic_auth_secret_missing {
-				import fhem_upstream_cached
+				import fhem_static_long_cache
 			}
 			handle {
-				import fhem_upstream_with_auth_header_cached
+				import fhem_static_long_cache
+			}
+		}
+		handle @fhem_static_short_cache {
+			handle @missing_mTLS_cert {
+				import authelia_forward_auth
+				import fhem_static_short_cache
+			}
+			handle {
+				import fhem_static_short_cache
 			}
 		}
 		handle @missing_mTLS_cert {

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -120,23 +120,16 @@
 		try_files {path} /__fhem_backend/fhem{uri}
 		handle_path /__fhem_backend/* {
 			reverse_proxy https://fhem-fhem-1.network_backend_net:8088 {
-				transport http {
-					versions 1.1
-					keepalive off
-					tls_server_name zeus.fritz.box
-					tls_trust_pool file {
-						pem_file /etc/ssl/ca/certs/blausee_ca.crt
-					}
-				}
+				import fhem_transport
 			}
 		}
 	}
 }
 (fhem_upstream_codemirror_cached) {
 	reverse_proxy https://fhem-fhem-1.network_backend_net:8083 {
-		header_down -Cache-Control
 		@fhem_codemirror_success status 200 206
 		handle_response @fhem_codemirror_success {
+			header -Cache-Control
 			header Cache-Control "public, max-age=3600"
 			copy_response_headers
 			copy_response
@@ -148,9 +141,9 @@
 (fhem_upstream_with_auth_header_codemirror_cached) {
 	reverse_proxy https://fhem-fhem-1.network_backend_net:8083 {
 		header_up Authorization {$FHEM_BASIC_AUTH_HEADER}
-		header_down -Cache-Control
 		@fhem_codemirror_success status 200 206
 		handle_response @fhem_codemirror_success {
+			header -Cache-Control
 			header Cache-Control "public, max-age=3600"
 			copy_response_headers
 			copy_response

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -86,6 +86,7 @@
 	transport http {
 		versions 1.1
 		keepalive off
+		max_conns_per_host 20
 		tls_server_name zeus.fritz.box
 		tls_trust_pool file {
 			pem_file /etc/ssl/ca/certs/blausee_ca.crt

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -113,7 +113,7 @@
 	file_server
 }
 (fhem_static_backend_fallback) {
-	rewrite * /__fhem_backend{uri}
+	rewrite * /__fhem_backend/fhem{uri}
 	handle_path /__fhem_backend/* {
 		reverse_proxy https://fhem-fhem-1.network_backend_net:8088 {
 			import fhem_transport
@@ -350,12 +350,7 @@ ui.{$CADDY_SUBDOMAIN} {
 	rewrite /images/* /fhem{uri}
 
 	reverse_proxy /fhem/images/* https://fhem-fhem-1.network_backend_net:8088 {
-		transport http {
-			tls_server_name zeus.fritz.box
-			tls_trust_pool file {
-				pem_file /etc/ssl/ca/certs/blausee_ca.crt
-			}
-		}
+		import fhem_transport
 	}
 	file_server
 	#import logging_info

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -115,8 +115,18 @@
 (fhem_static_backend_fallback) {
 	rewrite * /__fhem_backend/fhem{uri}
 	handle_path /__fhem_backend/* {
-		reverse_proxy https://fhem-fhem-1.network_backend_net:8088 {
-			import fhem_transport
+		handle @fhem_basic_auth_secret_missing {
+			reverse_proxy https://fhem-fhem-1.network_backend_net:8088 {
+				import fhem_client_cert_headers
+				import fhem_transport
+			}
+		}
+		handle {
+			reverse_proxy https://fhem-fhem-1.network_backend_net:8088 {
+				header_up Authorization {$FHEM_BASIC_AUTH_HEADER}
+				import fhem_client_cert_headers
+				import fhem_transport
+			}
 		}
 	}
 }

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -114,6 +114,21 @@
 	uri strip_prefix /fhem
 	file_server
 }
+(fhem_upstream_codemirror_cached) {
+	reverse_proxy https://fhem-fhem-1.network_backend_net:8083 {
+		header_down Cache-Control "public, max-age=3600"
+		import fhem_client_cert_headers
+		import fhem_transport
+	}
+}
+(fhem_upstream_with_auth_header_codemirror_cached) {
+	reverse_proxy https://fhem-fhem-1.network_backend_net:8083 {
+		header_up Authorization {$FHEM_BASIC_AUTH_HEADER}
+		header_down Cache-Control "public, max-age=3600"
+		import fhem_client_cert_headers
+		import fhem_transport
+	}
+}
 (logging_info) {
 	log {
 		level INFO
@@ -148,6 +163,7 @@ fhem.{$CADDY_SUBDOMAIN} {
 	encode gzip
 
 	@fhem_images path /fhem/images/*
+	@fhem_codemirror path /fhem/codemirror/*
 	route {
 		handle @fhem_images {
 			handle @missing_mTLS_cert {
@@ -156,6 +172,23 @@ fhem.{$CADDY_SUBDOMAIN} {
 			}
 			handle {
 				import fhem_static_long_cache
+			}
+		}
+		handle @fhem_codemirror {
+			handle @missing_mTLS_cert {
+				import authelia_forward_auth
+				handle @fhem_basic_auth_secret_missing {
+					import fhem_upstream_codemirror_cached
+				}
+				handle {
+					import fhem_upstream_with_auth_header_codemirror_cached
+				}
+			}
+			handle @fhem_basic_auth_secret_missing {
+				import fhem_upstream_codemirror_cached
+			}
+			handle {
+				import fhem_upstream_with_auth_header_codemirror_cached
 			}
 		}
 		handle @missing_mTLS_cert {

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -109,14 +109,38 @@
 	}
 }
 (fhem_static_long_cache) {
-	header Cache-Control "public, max-age=2592000"
 	root * /srv/fhem-www
 	uri strip_prefix /fhem
-	file_server
+	@fhem_static_existing file {path}
+	handle @fhem_static_existing {
+		header Cache-Control "public, max-age=2592000"
+		file_server
+	}
+	handle {
+		try_files {path} /__fhem_backend/fhem{uri}
+		handle_path /__fhem_backend/* {
+			reverse_proxy https://fhem-fhem-1.network_backend_net:8088 {
+				transport http {
+					versions 1.1
+					keepalive off
+					tls_server_name zeus.fritz.box
+					tls_trust_pool file {
+						pem_file /etc/ssl/ca/certs/blausee_ca.crt
+					}
+				}
+			}
+		}
+	}
 }
 (fhem_upstream_codemirror_cached) {
 	reverse_proxy https://fhem-fhem-1.network_backend_net:8083 {
-		header_down Cache-Control "public, max-age=3600"
+		header_down -Cache-Control
+		@fhem_codemirror_success status 200 206
+		handle_response @fhem_codemirror_success {
+			header Cache-Control "public, max-age=3600"
+			copy_response_headers
+			copy_response
+		}
 		import fhem_client_cert_headers
 		import fhem_transport
 	}
@@ -124,7 +148,13 @@
 (fhem_upstream_with_auth_header_codemirror_cached) {
 	reverse_proxy https://fhem-fhem-1.network_backend_net:8083 {
 		header_up Authorization {$FHEM_BASIC_AUTH_HEADER}
-		header_down Cache-Control "public, max-age=3600"
+		header_down -Cache-Control
+		@fhem_codemirror_success status 200 206
+		handle_response @fhem_codemirror_success {
+			header Cache-Control "public, max-age=3600"
+			copy_response_headers
+			copy_response
+		}
 		import fhem_client_cert_headers
 		import fhem_transport
 	}

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -114,12 +114,6 @@
 	uri strip_prefix /fhem
 	file_server
 }
-(fhem_static_short_cache) {
-	header Cache-Control "public, max-age=3600"
-	root * /srv/fhem-www
-	uri strip_prefix /fhem
-	file_server
-}
 (logging_info) {
 	log {
 		level INFO
@@ -154,7 +148,6 @@ fhem.{$CADDY_SUBDOMAIN} {
 	encode gzip
 
 	@fhem_images path /fhem/images/*
-	@fhem_static_short_cache path /fhem/codemirror/* /fhem/pgm2/*
 	route {
 		handle @fhem_images {
 			handle @missing_mTLS_cert {
@@ -163,15 +156,6 @@ fhem.{$CADDY_SUBDOMAIN} {
 			}
 			handle {
 				import fhem_static_long_cache
-			}
-		}
-		handle @fhem_static_short_cache {
-			handle @missing_mTLS_cert {
-				import authelia_forward_auth
-				import fhem_static_short_cache
-			}
-			handle {
-				import fhem_static_short_cache
 			}
 		}
 		handle @missing_mTLS_cert {

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -109,19 +109,14 @@
 	}
 }
 (fhem_static_long_cache) {
-	root * /srv/fhem-www
-	uri strip_prefix /fhem
-	@fhem_static_existing file {path}
-	handle @fhem_static_existing {
-		header Cache-Control "public, max-age=2592000"
-		file_server
-	}
-	handle {
-		rewrite * /__fhem_backend/fhem{uri}
-		handle_path /__fhem_backend/* {
-			reverse_proxy https://fhem-fhem-1.network_backend_net:8088 {
-				import fhem_transport
-			}
+	header Cache-Control "public, max-age=2592000"
+	file_server
+}
+(fhem_static_backend_fallback) {
+	rewrite * /__fhem_backend{uri}
+	handle_path /__fhem_backend/* {
+		reverse_proxy https://fhem-fhem-1.network_backend_net:8088 {
+			import fhem_transport
 		}
 	}
 }
@@ -195,13 +190,29 @@ fhem.{$CADDY_SUBDOMAIN} {
 				# Keep auth before the static rewrite so Authelia sees the original FHEM URL.
 				route {
 					import authelia_forward_auth
-					handle {
-						import fhem_static_long_cache
+					route {
+						root * /srv/fhem-www
+						uri strip_prefix /fhem
+						@fhem_static_existing_mtls file {path}
+						handle @fhem_static_existing_mtls {
+							import fhem_static_long_cache
+						}
+						handle {
+							import fhem_static_backend_fallback
+						}
 					}
 				}
 			}
-			handle {
-				import fhem_static_long_cache
+			route {
+				root * /srv/fhem-www
+				uri strip_prefix /fhem
+				@fhem_static_existing_images file {path}
+				handle @fhem_static_existing_images {
+					import fhem_static_long_cache
+				}
+				handle {
+					import fhem_static_backend_fallback
+				}
 			}
 		}
 		handle @fhem_codemirror {

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -108,6 +108,21 @@
 		import fhem_transport
 	}
 }
+(fhem_upstream_cached) {
+	reverse_proxy https://fhem-fhem-1.network_backend_net:8083 {
+		header_down Cache-Control "public, max-age=2592000"
+		import fhem_client_cert_headers
+		import fhem_transport
+	}
+}
+(fhem_upstream_with_auth_header_cached) {
+	reverse_proxy https://fhem-fhem-1.network_backend_net:8083 {
+		header_up Authorization {$FHEM_BASIC_AUTH_HEADER}
+		header_down Cache-Control "public, max-age=2592000"
+		import fhem_client_cert_headers
+		import fhem_transport
+	}
+}
 (logging_info) {
 	log {
 		level INFO
@@ -142,8 +157,24 @@ fhem.{$CADDY_SUBDOMAIN} {
 	encode gzip
 
 	@fhem_images path /fhem/images/*
-	header @fhem_images Cache-Control "public, max-age=2592000"
 	route {
+		handle @fhem_images {
+			handle @missing_mTLS_cert {
+				import authelia_forward_auth
+				handle @fhem_basic_auth_secret_missing {
+					import fhem_upstream_cached
+				}
+				handle {
+					import fhem_upstream_with_auth_header_cached
+				}
+			}
+			handle @fhem_basic_auth_secret_missing {
+				import fhem_upstream_cached
+			}
+			handle {
+				import fhem_upstream_with_auth_header_cached
+			}
+		}
 		handle @missing_mTLS_cert {
 			import authelia_forward_auth
 			handle @fhem_basic_auth_secret_missing {

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -117,7 +117,7 @@
 		file_server
 	}
 	handle {
-		try_files {path} /__fhem_backend/fhem{uri}
+		rewrite * /__fhem_backend/fhem{uri}
 		handle_path /__fhem_backend/* {
 			reverse_proxy https://fhem-fhem-1.network_backend_net:8088 {
 				import fhem_transport
@@ -129,9 +129,10 @@
 	reverse_proxy https://fhem-fhem-1.network_backend_net:8083 {
 		@fhem_codemirror_success status 200 206
 		handle_response @fhem_codemirror_success {
-			header -Cache-Control
-			header Cache-Control "public, max-age=3600"
-			copy_response_headers
+			copy_response_headers {
+				exclude Cache-Control
+			}
+			header >Cache-Control "public, max-age=3600"
 			copy_response
 		}
 		import fhem_client_cert_headers
@@ -143,9 +144,10 @@
 		header_up Authorization {$FHEM_BASIC_AUTH_HEADER}
 		@fhem_codemirror_success status 200 206
 		handle_response @fhem_codemirror_success {
-			header -Cache-Control
-			header Cache-Control "public, max-age=3600"
-			copy_response_headers
+			copy_response_headers {
+				exclude Cache-Control
+			}
+			header >Cache-Control "public, max-age=3600"
 			copy_response
 		}
 		import fhem_client_cert_headers

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -167,8 +167,13 @@ fhem.{$CADDY_SUBDOMAIN} {
 	route {
 		handle @fhem_images {
 			handle @missing_mTLS_cert {
-				import authelia_forward_auth
-				import fhem_static_long_cache
+				# Keep auth before the static rewrite so Authelia sees the original FHEM URL.
+				route {
+					import authelia_forward_auth
+					handle {
+						import fhem_static_long_cache
+					}
+				}
 			}
 			handle {
 				import fhem_static_long_cache

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -86,6 +86,7 @@
 	transport http {
 		versions 1.1
 		keepalive off
+		# Limit concurrency to avoid FHEM 401/502 under image bursts; 20 stayed stable in load tests.
 		max_conns_per_host 20
 		tls_server_name zeus.fritz.box
 		tls_trust_pool file {
@@ -93,6 +94,7 @@
 		}
 	}
 }
+
 (fhem_upstream) {
 	reverse_proxy https://fhem-fhem-1.network_backend_net:8083 {
 		import fhem_client_cert_headers
@@ -138,6 +140,9 @@ fhem.{$CADDY_SUBDOMAIN} {
 	import missing_mTLS_cert
 	import fhem_basic_auth_secret_missing
 	encode gzip
+
+	@fhem_images path /fhem/images/*
+	header @fhem_images Cache-Control "public, max-age=2592000"
 	route {
 		handle @missing_mTLS_cert {
 			import authelia_forward_auth

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,10 +31,10 @@ services:
         ipv6_address: fd00:10:2:11::19
     restart: unless-stopped
     user: 5100:5100
-    group_add:
-      - "1003"
     cap_add:
       - NET_ADMIN
+    group_add:
+      - "1003"
 
   fetch-workflow-assets:
     image: curlimages/curl:8.20.0@sha256:b3f1fb2a51d923260350d21b8654bbc607164a987e2f7c84a0ac199a67df812a

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     volumes:
       - ./caddy:/etc/caddy
       - ./site:/srv
+      - /opt/docker/fhem/app/www:/srv/fhem-www:ro
       - /opt/docker/caddy/data:/data
       - /opt/docker/caddy/caddy_config:/config
       - /opt/docker/rootca/root-ca.cert.pem:/etc/ssl/ca/certs/blausee_ca.crt:ro
@@ -30,6 +31,8 @@ services:
         ipv6_address: fd00:10:2:11::19
     restart: unless-stopped
     user: 5100:5100
+    group_add:
+      - "1003"
     cap_add:
       - NET_ADMIN
 

--- a/scripts/test-auth-endpoints-e2e.sh
+++ b/scripts/test-auth-endpoints-e2e.sh
@@ -52,10 +52,33 @@ assert_no_upstream_header() {
   echo "OK: no upstream proxy header for $host$path"
 }
 
+wait_for_code() {
+  local method="$1" host="$2" path="$3" auth="$4" want="$5"
+  local attempts=30
+  local delay=1
+  local got=""
+
+  for _ in $(seq 1 "$attempts"); do
+    got="$(req_code "$method" "$host" "$path" "$auth")"
+    if [[ "$got" == "$want" ]]; then
+      echo "OK: ready $method $host$path -> $got"
+      return 0
+    fi
+    if [[ "$got" != "502" && "$got" != "503" && "$got" != "504" ]]; then
+      break
+    fi
+    sleep "$delay"
+  done
+
+  echo "FAIL: $method $host$path ready check (got=$got want=$want)" >&2
+  exit 1
+}
+
 echo "Starting isolated E2E stack..."
 docker compose -f "$COMPOSE_FILE" up -d --wait
 
 # landing.* protected endpoints
+wait_for_code GET landing.test /backup/status none 401
 assert_eq "$(req_code GET landing.test /backup/status none)" "401" "landing /backup/status requires auth"
 assert_eq "$(req_code GET landing.test /backup/status auth)" "200" "landing /backup/status works with auth"
 assert_eq "$(req_code GET landing.test /backup/names none)" "401" "landing /backup/names requires auth"

--- a/scripts/test-auth-protected-endpoints.sh
+++ b/scripts/test-auth-protected-endpoints.sh
@@ -50,7 +50,7 @@ require_pattern "handle @landingBackupNames {" "Missing landingBackupNames handl
 
 # FHEM image auth must keep the original URL through Authelia before strip_prefix runs.
 require_pattern "Keep auth before the static rewrite so Authelia sees the original FHEM URL." "Missing FHEM image auth ordering guard"
-require_pattern "rewrite * /__fhem_backend/fhem{uri}" "Missing FHEM image backend fallback"
+require_pattern "rewrite * /__fhem_backend{uri}" "Missing FHEM image backend fallback"
 require_pattern "handle_path /__fhem_backend/* {" "Missing FHEM image backend proxy handler"
 
 # Workflow host webhook protections must remain explicit.

--- a/scripts/test-auth-protected-endpoints.sh
+++ b/scripts/test-auth-protected-endpoints.sh
@@ -50,7 +50,7 @@ require_pattern "handle @landingBackupNames {" "Missing landingBackupNames handl
 
 # FHEM image auth must keep the original URL through Authelia before strip_prefix runs.
 require_pattern "Keep auth before the static rewrite so Authelia sees the original FHEM URL." "Missing FHEM image auth ordering guard"
-require_pattern "try_files {path} /__fhem_backend/fhem{uri}" "Missing FHEM image backend fallback"
+require_pattern "rewrite * /__fhem_backend/fhem{uri}" "Missing FHEM image backend fallback"
 require_pattern "handle_path /__fhem_backend/* {" "Missing FHEM image backend proxy handler"
 
 # Workflow host webhook protections must remain explicit.

--- a/scripts/test-auth-protected-endpoints.sh
+++ b/scripts/test-auth-protected-endpoints.sh
@@ -50,7 +50,7 @@ require_pattern "handle @landingBackupNames {" "Missing landingBackupNames handl
 
 # FHEM image auth must keep the original URL through Authelia before strip_prefix runs.
 require_pattern "Keep auth before the static rewrite so Authelia sees the original FHEM URL." "Missing FHEM image auth ordering guard"
-require_pattern "rewrite * /__fhem_backend{uri}" "Missing FHEM image backend fallback"
+require_pattern "rewrite * /__fhem_backend/fhem{uri}" "Missing FHEM image backend fallback"
 require_pattern "handle_path /__fhem_backend/* {" "Missing FHEM image backend proxy handler"
 
 # Workflow host webhook protections must remain explicit.

--- a/scripts/test-auth-protected-endpoints.sh
+++ b/scripts/test-auth-protected-endpoints.sh
@@ -50,6 +50,8 @@ require_pattern "handle @landingBackupNames {" "Missing landingBackupNames handl
 
 # FHEM image auth must keep the original URL through Authelia before strip_prefix runs.
 require_pattern "Keep auth before the static rewrite so Authelia sees the original FHEM URL." "Missing FHEM image auth ordering guard"
+require_pattern "try_files {path} /__fhem_backend/fhem{uri}" "Missing FHEM image backend fallback"
+require_pattern "handle_path /__fhem_backend/* {" "Missing FHEM image backend proxy handler"
 
 # Workflow host webhook protections must remain explicit.
 require_pattern 'header X-Telegram-Bot-Api-Secret-Token {$TELEGRAM_WEBHOOK_SECRET}' 'Missing Telegram secret header matcher'

--- a/scripts/test-auth-protected-endpoints.sh
+++ b/scripts/test-auth-protected-endpoints.sh
@@ -48,6 +48,9 @@ require_pattern "rewrite * /webhook/backup/names" "Missing rewrite for /backup/n
 require_pattern "handle @landingBackupStatus {" "Missing landingBackupStatus handle"
 require_pattern "handle @landingBackupNames {" "Missing landingBackupNames handle"
 
+# FHEM image auth must keep the original URL through Authelia before strip_prefix runs.
+require_pattern "Keep auth before the static rewrite so Authelia sees the original FHEM URL." "Missing FHEM image auth ordering guard"
+
 # Workflow host webhook protections must remain explicit.
 require_pattern 'header X-Telegram-Bot-Api-Secret-Token {$TELEGRAM_WEBHOOK_SECRET}' 'Missing Telegram secret header matcher'
 require_pattern "path /webhook/scanservjs/telegram/reissue /webhook-test/scanservjs/telegram/reissue" "Missing Telegram webhook path matcher"


### PR DESCRIPTION
## What changed
- Limited Caddy's FHEM upstream connections via `max_conns_per_host 20` in the shared `fhem_transport` block.

## Why
- Parallel image loads against FHEM were reproducing intermittent `401` responses from FHEM and occasional `502` dial timeouts from Caddy.
- The tests showed the issue only under higher concurrency, so throttling the upstream is the first mitigation step.

## Validation
- Reproduced the issue with parallel `curl` requests.
- Confirmed that the branch was pushed and is ready for a Portainer-based deployment test.

## Notes
- This is a mitigation, not the root-cause fix.
- Next step is to rerun the load test after deploying this branch and compare the error rate.