### PR TITLE
Configure n8n OAuth redirects behind Caddy

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,27 @@ keeps n8n OAuth2 callback URLs such as `https://workflow.sidey.blausee.eu/rest/o
 reachable by external OAuth providers without exposing the generic n8n editor or REST API to clients
 without a certificate.
 
+### n8n OAuth behind Caddy
+
+The n8n stack is maintained separately from this reverse proxy. Configure that stack with the public
+workflow origin so n8n generates public OAuth redirect URLs instead of `http://localhost:5678`:
+
+```yaml
+environment:
+  WEBHOOK_URL: https://workflow.${CADDY_SUBDOMAIN}/
+  N8N_PROXY_HOPS: "1"
+```
+
+Caddy explicitly forwards `X-Forwarded-Host` and `X-Forwarded-Proto` to n8n. Register the exact URL
+shown by the n8n credential in Google Cloud. With the standard n8n endpoint it is:
+
+```text
+https://workflow.<CADDY_SUBDOMAIN>/rest/oauth2-credential/callback
+```
+
+The `http://localhost:5678/rest/oauth2-credential/callback` variant is only valid when n8n is running
+locally on the same machine as the browser.
+
 ## Landing Page
 
 `landing.{$CADDY_SUBDOMAIN}` is protected by Authelia and serves static files from

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -475,6 +475,9 @@ workflow.{$CADDY_SUBDOMAIN} {
 		handle @workflowMtls {
 			import n8n_upstream
 		}
+		handle {
+			respond "workflow fallback" 404
+		}
 	}
 	import logging_info
 }

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -166,6 +166,8 @@
 }
 (n8n_upstream) {
 	reverse_proxy https://n8n-n8n-1.network_backend_net:5678 {
+		header_up X-Forwarded-Host {host}
+		header_up X-Forwarded-Proto {scheme}
 		header_up X-Client-Cert-Subject {tls_client_subject}
 		header_up X-Client-Cert-Serial {tls_client_serial}
 		header_up X-Client-Cert-Fingerprint {tls_client_fingerprint}

--- a/scripts/test-auth-endpoints-e2e.sh
+++ b/scripts/test-auth-endpoints-e2e.sh
@@ -12,7 +12,12 @@ trap cleanup EXIT
 
 req_code() {
   local method="$1" host="$2" path="$3" auth="$4" extra_header="${5:-}"
-  local -a args=( -sS -o /dev/null -w "%{http_code}" -X "$method" -H "Host: $host" )
+  local -a args=( -sS -o /dev/null -w "%{http_code}" -H "Host: $host" )
+  if [[ "$method" == "HEAD" ]]; then
+    args+=( --head )
+  else
+    args+=( -X "$method" )
+  fi
   if [[ "$auth" == "auth" ]]; then
     args+=( -H "X-Test-Auth: allow" )
   fi
@@ -32,6 +37,15 @@ req_header() {
     args+=( -H "$extra_header" )
   fi
   curl "${args[@]}" "$BASE_URL$path" | awk -v h="$header_name" 'BEGIN{IGNORECASE=1} $0 ~ "^"h":" {print; found=1} END{if(!found) exit 1}'
+}
+
+req_body() {
+  local method="$1" host="$2" path="$3" auth="$4"
+  local -a args=( -sS -X "$method" -H "Host: $host" )
+  if [[ "$auth" == "auth" ]]; then
+    args+=( -H "X-Test-Auth: allow" )
+  fi
+  curl "${args[@]}" "$BASE_URL$path"
 }
 
 assert_eq() {
@@ -93,6 +107,19 @@ assert_no_upstream_header GET landing.test /backup/rest/workflows auth
 # workflow.* protected webhook path
 assert_eq "$(req_code POST workflow.test /webhook/protected none)" "401" "workflow protected webhook requires auth without mTLS/exception"
 assert_eq "$(req_code POST workflow.test /webhook/protected auth)" "200" "workflow protected webhook works with auth"
+
+# The exact n8n OAuth callback is public, preserves provider state, and forwards its public origin.
+oauth_response="$(req_body GET workflow.test '/rest/oauth2-credential/callback?code=test-code&state=test-state' none)"
+assert_eq "$(printf '%s' "$oauth_response" | jq -r .path)" "/rest/oauth2-credential/callback" "OAuth callback reaches n8n"
+assert_eq "$(printf '%s' "$oauth_response" | jq -r .query)" "code=test-code&state=test-state" "OAuth callback preserves query parameters"
+assert_eq "$(printf '%s' "$oauth_response" | jq -r .forwardedHost)" "workflow.test" "OAuth callback forwards the public host"
+assert_eq "$(printf '%s' "$oauth_response" | jq -r .forwardedProto)" "http" "OAuth callback forwards the original protocol"
+assert_eq "$(req_code HEAD workflow.test /rest/oauth2-credential/callback none)" "200" "OAuth callback supports HEAD"
+assert_eq "$(req_code OPTIONS workflow.test /rest/oauth2-credential/callback none)" "200" "OAuth callback supports OPTIONS"
+assert_eq "$(req_code POST workflow.test /rest/oauth2-credential/callback none)" "404" "OAuth callback rejects POST"
+assert_no_upstream_header POST workflow.test /rest/oauth2-credential/callback none
+assert_eq "$(req_code GET workflow.test /rest/workflows none)" "404" "unrelated n8n REST endpoints stay private"
+assert_no_upstream_header GET workflow.test /rest/workflows none
 
 # Explicit Telegram exception (no auth but header secret)
 assert_eq "$(req_code POST workflow.test /webhook/scanservjs/telegram/reissue none "X-Telegram-Bot-Api-Secret-Token: test-telegram-secret")" "200" "telegram exception works without auth when secret header matches"

--- a/scripts/test-auth-protected-endpoints.sh
+++ b/scripts/test-auth-protected-endpoints.sh
@@ -69,5 +69,6 @@ require_pattern "path /rest/oauth2-credential*" "Missing n8n OAuth callback path
 require_pattern "handle @oauth2Credential {" "Missing n8n OAuth callback handler"
 require_pattern "header_up X-Forwarded-Host {host}" "Missing n8n forwarded host header"
 require_pattern "header_up X-Forwarded-Proto {scheme}" "Missing n8n forwarded protocol header"
+require_pattern 'respond "workflow fallback" 404' "Missing workflow fallback for unmatched requests"
 
 echo "Auth endpoint policy checks passed: $CADDYFILE"

--- a/scripts/test-auth-protected-endpoints.sh
+++ b/scripts/test-auth-protected-endpoints.sh
@@ -63,4 +63,11 @@ require_pattern "import authelia_forward_auth" "Missing authelia_forward_auth im
 require_pattern "@webhooksMtls {" "Missing mTLS webhook matcher"
 require_pattern "@webhooksAuthelia {" "Missing non-mTLS webhook matcher"
 
+# n8n OAuth callbacks must stay narrowly public and retain their external request origin.
+require_pattern "method GET HEAD OPTIONS" "Missing OAuth callback method restriction"
+require_pattern "path /rest/oauth2-credential*" "Missing n8n OAuth callback path matcher"
+require_pattern "handle @oauth2Credential {" "Missing n8n OAuth callback handler"
+require_pattern "header_up X-Forwarded-Host {host}" "Missing n8n forwarded host header"
+require_pattern "header_up X-Forwarded-Proto {scheme}" "Missing n8n forwarded protocol header"
+
 echo "Auth endpoint policy checks passed: $CADDYFILE"

--- a/tests/e2e/Caddyfile
+++ b/tests/e2e/Caddyfile
@@ -11,7 +11,10 @@
 }
 
 (n8n_upstream) {
-  reverse_proxy http://n8n-mock:5678
+  reverse_proxy http://n8n-mock:5678 {
+    header_up X-Forwarded-Host {host}
+    header_up X-Forwarded-Proto {scheme}
+  }
 }
 
 http://landing.test {

--- a/tests/e2e/mock_n8n.py
+++ b/tests/e2e/mock_n8n.py
@@ -23,6 +23,9 @@ class Handler(BaseHTTPRequestHandler):
     def do_POST(self):
         self._handle()
 
+    def do_OPTIONS(self):
+        self._handle()
+
     def _handle(self, head=False):
         parsed = urlparse(self.path)
         path = parsed.path
@@ -73,7 +76,14 @@ class Handler(BaseHTTPRequestHandler):
 
         # Generic webhook sink for protected workflow endpoints.
         if path.startswith("/webhook/") or path.startswith("/webhook-test/") or path.startswith("/rest/oauth2-credential"):
-            payload = {"ok": True, "path": path, "method": self.command}
+            payload = {
+                "ok": True,
+                "path": path,
+                "query": parsed.query,
+                "method": self.command,
+                "forwardedHost": self.headers.get("X-Forwarded-Host"),
+                "forwardedProto": self.headers.get("X-Forwarded-Proto"),
+            }
             if head:
                 self.send_response(200)
                 self.send_header("Content-Type", "application/json")


### PR DESCRIPTION
## What changed

- explicitly forward the public host and protocol from Caddy to n8n
- document the required `WEBHOOK_URL` and `N8N_PROXY_HOPS` settings for the separate n8n stack
- extend the isolated n8n mock and endpoint policy checks for OAuth callbacks
- verify callback query preservation, allowed methods, and protection of unrelated REST endpoints

## Why

A self-hosted n8n instance behind Caddy can otherwise advertise `http://localhost:5678/rest/oauth2-credential/callback`, which is only valid for a truly local development instance. Google OAuth needs the externally reachable HTTPS callback URL, while the remaining n8n REST API must stay private.

## Impact

After the documented n8n environment settings are applied, credentials can use `https://workflow.<CADDY_SUBDOMAIN>/rest/oauth2-credential/callback`. The existing narrow public callback route remains limited to `GET`, `HEAD`, and `OPTIONS`; `POST` and unrelated `/rest/*` endpoints are not exposed.

## Validation

- `bash scripts/test-auth-protected-endpoints.sh caddy/Caddyfile`
- `bash scripts/test-auth-endpoints-e2e.sh`
- shell syntax checks for both auth test scripts
- Python compile check for `tests/e2e/mock_n8n.py`
- `git diff --check`
- Caddyfile successfully adapted with Caddy 2.11.4; full standalone validation cannot provision the repository's private production PKI files in the isolated container