### PR TITLE
Disable HTTP/3 for FHEM mTLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ When a valid client certificate is present, Caddy also forwards these headers to
 - `X-Client-Cert-Subject`
 - `X-Client-Cert-Fingerprint`
 
+HTTP/3 is disabled on Caddy's shared HTTPS listener because client-certificate authentication is
+not supported over HTTP/3. Since Caddy configures protocols per listener rather than per virtual
+host, all HTTPS sites use HTTP/1.1 or HTTP/2 so the browser keeps presenting the FHEM client
+certificate on subsequent requests.
+
 The route uses `mTLS_optional`. Without a client certificate, the workflow host only serves the
 local workflow asset store from `/assets/*`, exposes `GET/HEAD /api/me` behind Authelia without
 requiring a client certificate, protects the browser UI for `/webhook/github-pr-dashboard` with

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -1,6 +1,11 @@
 {
 	acme_ca https://acme.zerossl.com/v2/DV90
 	email sven@blausee.eu
+	# Client certificate authentication is not supported over HTTP/3. All HTTPS
+	# sites share this listener, so keep it on HTTP/1.1 and HTTP/2 for FHEM mTLS.
+	servers :443 {
+		protocols h1 h2
+	}
 	pki {
 		ca blausee_ca {
 			root {

--- a/scripts/test-auth-protected-endpoints.sh
+++ b/scripts/test-auth-protected-endpoints.sh
@@ -49,6 +49,8 @@ require_pattern "handle @landingBackupStatus {" "Missing landingBackupStatus han
 require_pattern "handle @landingBackupNames {" "Missing landingBackupNames handle"
 
 # FHEM image auth must keep the original URL through Authelia before strip_prefix runs.
+require_pattern "servers :443 {" "Missing HTTPS server configuration required for FHEM mTLS"
+require_pattern "protocols h1 h2" "HTTP/3 must be disabled because FHEM uses client certificate authentication"
 require_pattern "Keep auth before the static rewrite so Authelia sees the original FHEM URL." "Missing FHEM image auth ordering guard"
 require_pattern "rewrite * /__fhem_backend/fhem{uri}" "Missing FHEM image backend fallback"
 require_pattern "handle_path /__fhem_backend/* {" "Missing FHEM image backend proxy handler"


### PR DESCRIPTION
## What changed

- disable HTTP/3 on Caddy's shared HTTPS listener
- keep HTTP/1.1 and HTTP/2 enabled
- add a regression check for the listener protocols
- document the listener-wide impact

## Why

Browsers can initially present the FHEM client certificate over HTTP/2, then switch subsequent requests to HTTP/3 after Caddy advertises it. Caddy does not support mTLS over HTTP/3, so those requests lose the client certificate and fall back to Authelia.

Caddy configures protocols per listener rather than per virtual host. Because the HTTPS sites share port 443, HTTP/3 must be disabled for the shared listener to keep FHEM mTLS reliable.

## Validation

- `bash scripts/test-auth-protected-endpoints.sh`
- `git diff --check`
- Caddy 2.11.4 successfully adapted the Caddyfile with test environment values