### PR TITLE
fix: forward missing n8n editor assets with mTLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ not supported over HTTP/3. Since Caddy configures protocols per listener rather 
 host, all HTTPS sites use HTTP/1.1 or HTTP/2 so the browser keeps presenting the FHEM client
 certificate on subsequent requests.
 
-The route uses `mTLS_optional`. Without a client certificate, the workflow host only serves the
-local workflow asset store from `/assets/*`, exposes `GET/HEAD /api/me` behind Authelia without
+The route uses `mTLS_optional`. Without a client certificate, the workflow host serves matching
+files from the local workflow asset store under `/assets/*`; missing assets are not proxied.
+With a client certificate, missing `/assets/*` files are forwarded to n8n so that the n8n editor's versioned JavaScript and CSS assets work correctly. The host also exposes
+`GET/HEAD /api/me` behind Authelia without
 requiring a client certificate, protects the browser UI for `/webhook/github-pr-dashboard` with
 Authelia, and forwards the `POST` webhook request to n8n. With a client certificate, all remaining
 `workflow.*` paths are forwarded to n8n after the explicit path exceptions have been evaluated. If a

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -451,8 +451,21 @@ workflow.{$CADDY_SUBDOMAIN} {
 	}
 	route {
 		handle @workflowAssets {
-			root * /srv/workflow
-			file_server
+			# Keep locally managed workflow assets, but let n8n serve its own
+			# versioned editor assets (for example /assets/index-*.js).
+			route {
+				root * /srv/workflow
+				@localWorkflowAsset file {path}
+				handle @localWorkflowAsset {
+					file_server
+				}
+				handle @workflowMtls {
+					import n8n_upstream
+				}
+				handle {
+					respond 404
+				}
+			}
 		}
 		handle @apiMe {
 			import authelia_forward_auth

--- a/scripts/test-auth-protected-endpoints.sh
+++ b/scripts/test-auth-protected-endpoints.sh
@@ -65,4 +65,11 @@ require_pattern "import authelia_forward_auth" "Missing authelia_forward_auth im
 require_pattern "@webhooksMtls {" "Missing mTLS webhook matcher"
 require_pattern "@webhooksAuthelia {" "Missing non-mTLS webhook matcher"
 
+# Workflow assets must fall back to n8n only when mTLS is present. A broad
+# file_server for /assets/* would shadow the n8n editor's versioned assets.
+require_pattern "@localWorkflowAsset file {path}" "Missing local workflow asset matcher"
+require_pattern "handle @localWorkflowAsset {" "Missing local workflow asset handler"
+require_pattern "handle @workflowMtls {" "Missing mTLS workflow asset fallback"
+require_pattern "respond 404" "Missing non-mTLS workflow asset fallback response"
+
 echo "Auth endpoint policy checks passed: $CADDYFILE"

--- a/scripts/test-auth-protected-endpoints.sh
+++ b/scripts/test-auth-protected-endpoints.sh
@@ -31,6 +31,11 @@ require_pattern() {
   fi
 }
 
+asset_route_has() {
+  local pattern="$1"
+  awk '/handle @workflowAssets \{/{in_asset=1} in_asset {print} /handle @apiMe \{/{exit}' "$CADDYFILE" | grep -F -- "$pattern" >/dev/null
+}
+
 forbid_pattern() {
   local pattern="$1"
   local msg="$2"
@@ -67,9 +72,9 @@ require_pattern "@webhooksAuthelia {" "Missing non-mTLS webhook matcher"
 
 # Workflow assets must fall back to n8n only when mTLS is present. A broad
 # file_server for /assets/* would shadow the n8n editor's versioned assets.
-require_pattern "@localWorkflowAsset file {path}" "Missing local workflow asset matcher"
-require_pattern "handle @localWorkflowAsset {" "Missing local workflow asset handler"
-require_pattern "handle @workflowMtls {" "Missing mTLS workflow asset fallback"
-require_pattern "respond 404" "Missing non-mTLS workflow asset fallback response"
+asset_route_has "@localWorkflowAsset file {path}" || fail "Missing local workflow asset matcher in asset route"
+asset_route_has "handle @localWorkflowAsset {" || fail "Missing local workflow asset handler in asset route"
+asset_route_has "handle @workflowMtls {" || fail "Missing mTLS workflow asset fallback in asset route"
+asset_route_has "respond 404" || fail "Missing non-mTLS workflow asset fallback response in asset route"
 
 echo "Auth endpoint policy checks passed: $CADDYFILE"


### PR DESCRIPTION
## Summary

- Preserve locally managed files under `/assets/*`.
- Forward missing n8n editor assets to n8n when a verified mTLS certificate is present.
- Return 404 for missing workflow assets without mTLS and document the behavior.

## Root cause

The previous `/assets/*` file server handled every request and returned 404 for n8n-generated versioned assets such as `assets/index-B3HUmtOC.js`, so those requests never reached n8n.

## Validation

- `bash scripts/test-auth-protected-endpoints.sh`
- `bash scripts/test-auth-endpoints-e2e.sh`
- Caddy 2.11.4 config adaptation with test environment variables
